### PR TITLE
[Lechros] step-1 체스 프로젝트 시작

### DIFF
--- a/java-chess.iml
+++ b/java-chess.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="assertj.core" level="project" />
+    <orderEntry type="library" name="junit.jupiter" level="project" />
+  </component>
+</module>

--- a/src/main/piece/Pawn.java
+++ b/src/main/piece/Pawn.java
@@ -1,0 +1,15 @@
+package piece;
+
+public class Pawn {
+
+    private final String color;
+
+    public Pawn(final String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+}

--- a/src/test/piece/PawnTest.java
+++ b/src/test/piece/PawnTest.java
@@ -1,0 +1,17 @@
+package piece;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PawnTest {
+
+    @Test
+    @DisplayName("흰색 폰이 생성되어야 한다")
+    public void create() {
+        Pawn pawn = new Pawn("white");
+        assertThat(pawn.getColor()).isEqualTo("white");
+    }
+
+}

--- a/src/test/piece/PawnTest.java
+++ b/src/test/piece/PawnTest.java
@@ -7,11 +7,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PawnTest {
 
+    private Pawn pawn;
+
     @Test
-    @DisplayName("흰색 폰이 생성되어야 한다")
+    @DisplayName("생성자에 전달된 색의 폰이 생성되어야 한다")
     public void create() {
-        Pawn pawn = new Pawn("white");
-        assertThat(pawn.getColor()).isEqualTo("white");
+        final String WHITE = "white";
+        final String BLACK = "black";
+
+        pawn = new Pawn(WHITE);
+        verifyPawn(WHITE);
+
+        pawn = new Pawn(BLACK);
+        verifyPawn(BLACK);
+    }
+
+    private void verifyPawn(final String color) {
+        assertThat(pawn.getColor()).isEqualTo(color);
     }
 
 }


### PR DESCRIPTION
## 구현 내용
IntelliJ 빌드 시스템을 사용하여 모듈을 생성했습니다.
체스 기물 중 폰을 구현하고, 기물의 색상을 저장합니다.
폰의 생성자 및 색상 테스트를 추가했습니다.

## 고민 사항
`verifyPawn` 메소드에 폰 객체를 인자로 전달하지 않기 위해 클래스의 private 필드에 저장하여 전달하도록 구현했습니다.

## 기타
(없음)