### PR TITLE
[yudonggeun] step-2 체스판 생성

### DIFF
--- a/src/main/java/com/example/demo/context/Board.java
+++ b/src/main/java/com/example/demo/context/Board.java
@@ -1,0 +1,31 @@
+package com.example.demo.context;
+
+import com.example.demo.piece.Color;
+import com.example.demo.piece.Pawn;
+
+public class Board {
+
+    Pawn[][] pieceLocation = new Pawn[8][8];
+
+    /**
+     * <p>
+     * 보드는 생성시에 정해진 규칙에 따라서 말을 배치한 초기상태를 가져야한다.
+     * </p>
+     * <img src="https://upload.wikimedia.org/wikipedia/commons/c/cc/Immortal_game_animation.gif" />
+     */
+    public Board() {
+        // init pawn
+        for (File file : File.values()) {
+            setPiece(Rank.TWO, file, new Pawn(Color.BLACK));
+            setPiece(Rank.SEVEN, File.G, new Pawn(Color.WHITE));
+        }
+    }
+
+    public void setPiece(Rank row, File column, Pawn pawn){
+        pieceLocation[row.index()][column.index()] = pawn;
+    }
+
+    public Pawn getPiece(Rank row, File column){
+        return pieceLocation[row.index()][column.index()];
+    }
+}

--- a/src/main/java/com/example/demo/context/File.java
+++ b/src/main/java/com/example/demo/context/File.java
@@ -1,0 +1,19 @@
+package com.example.demo.context;
+
+/**
+ * 체스에서 File은 열을 나타냅니다.
+ * File은 0부터 7까지 총 8개의 열을 가지고 Rank(행)과 구분하기 위해서 a부터 h까지의 문자로 표현합니다.
+ */
+public enum File {
+    A(0), B(1), C(2), D(3), E(4), F(5), G(6), H(7);
+
+    private final int index;
+
+    File(int index) {
+        this.index = index;
+    }
+
+    public int index(){
+        return this.index;
+    }
+}

--- a/src/main/java/com/example/demo/context/Rank.java
+++ b/src/main/java/com/example/demo/context/Rank.java
@@ -1,0 +1,19 @@
+package com.example.demo.context;
+
+/**
+ * 체스에서 Rank는 행을 나타냅니다.
+ * Rank는 0부터 7까지 총 8개의 행을 가집니다.
+ */
+public enum Rank {
+    ONE(0), TWO(1), THREE(2), FOUR(3), FIVE(4), SIX(5), SEVEN(6), EIGHT(7);
+
+    private final int index;
+
+    Rank(int index) {
+        this.index = index;
+    }
+
+    public int index() {
+        return this.index;
+    }
+}

--- a/src/main/java/com/example/demo/piece/Color.java
+++ b/src/main/java/com/example/demo/piece/Color.java
@@ -1,0 +1,5 @@
+package com.example.demo.piece;
+
+public enum Color {
+    WHITE, BLACK
+}

--- a/src/main/java/com/example/demo/piece/Pawn.java
+++ b/src/main/java/com/example/demo/piece/Pawn.java
@@ -1,17 +1,17 @@
 package com.example.demo.piece;
 
 public class Pawn {
-    private String color;
+    private Color color;
 
     public Pawn() {
-        this("white");
+        this(Color.WHITE);
     }
 
-    public Pawn(String color) {
+    public Pawn(Color color) {
         this.color = color;
     }
 
-    public String getColor() {
+    public Color getColor() {
         return color;
     }
 }

--- a/src/main/java/com/example/demo/piece/Pawn.java
+++ b/src/main/java/com/example/demo/piece/Pawn.java
@@ -3,6 +3,10 @@ package com.example.demo.piece;
 public class Pawn {
     private String color;
 
+    public Pawn() {
+        this("white");
+    }
+
     public Pawn(String color) {
         this.color = color;
     }

--- a/src/test/java/com/example/demo/context/BoardTest.java
+++ b/src/test/java/com/example/demo/context/BoardTest.java
@@ -1,0 +1,28 @@
+package com.example.demo.context;
+
+import com.example.demo.piece.Color;
+import com.example.demo.piece.Pawn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoardTest {
+
+    @Test
+    @DisplayName("보드를 생성하면 폰의 초기 상태가 설정되어 있다.")
+    public void create_pawn() {
+        Board board = new Board();
+
+        for(File file: File.values()){
+            Pawn black = board.getPiece(Rank.TWO, file);
+            assertThat(black).isInstanceOf(Pawn.class);
+            assertThat(black.getColor()).isEqualTo(Color.BLACK);
+
+            Pawn white = board.getPiece(Rank.SEVEN, file);
+            assertThat(white).isInstanceOf(Pawn.class);
+            assertThat(white.getColor()).isEqualTo(Color.WHITE);
+        }
+    }
+
+}

--- a/src/test/java/com/example/demo/piece/PawnTest.java
+++ b/src/test/java/com/example/demo/piece/PawnTest.java
@@ -3,7 +3,7 @@ package com.example.demo.piece;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,16 +11,20 @@ class PawnTest {
 
     @DisplayName("폰 생성시 색상을 가진다.")
     @ParameterizedTest
-    @ValueSource(strings = {"white", "black"})
-    public void create(final String color){
+    @MethodSource("colors")
+    public void create(final Color color){
         Pawn pawn = new Pawn(color);
         assertThat(pawn.getColor()).isEqualTo(color);
+    }
+
+    private static Color[] colors() {
+        return new Color[] {Color.WHITE, Color.BLACK};
     }
 
     @Test
     @DisplayName("색을 지정하지 않고 폰을 생성하면 흰색이다.")
     public void create_기본생성자() {
         Pawn pawn = new Pawn();
-        assertThat(pawn.getColor()).isEqualTo("white");
+        assertThat(pawn.getColor()).isEqualTo(Color.WHITE);
     }
 }

--- a/src/test/java/com/example/demo/piece/PawnTest.java
+++ b/src/test/java/com/example/demo/piece/PawnTest.java
@@ -1,6 +1,7 @@
 package com.example.demo.piece;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -14,5 +15,12 @@ class PawnTest {
     public void create(final String color){
         Pawn pawn = new Pawn(color);
         assertThat(pawn.getColor()).isEqualTo(color);
+    }
+
+    @Test
+    @DisplayName("색을 지정하지 않고 폰을 생성하면 흰색이다.")
+    public void create_기본생성자() {
+        Pawn pawn = new Pawn();
+        assertThat(pawn.getColor()).isEqualTo("white");
     }
 }


### PR DESCRIPTION
## 구현 내용
- 체스판을 관리하는 객체인 `Board`를 구현
- 체스판에서 행과 열을 가르킬때, 1 ~ 8, A ~ H 기호를 활용해서 위치를 표시하는 Rank, File을 구현
- 보드에 정해진 말만을 입력할 수 있도록 `getPiece`, `setPiece` 함수를 구현
- Pawn의 색상을 나타내는 Color 구현

## 고민 사항
- 요구사항에서는 보드에 존재하는 말의 개수를 조회하는 `size()` 함수를 생성하는 예제가 있었습니다. 하지만 체스에서 보드 위에서 말의 개수를 나타내는 기능이 필요하지 않은 기능이라는 생각이 들어서 `size()`를 구현하지 않았습니다.

- 체스판에서 말의 위치를 나타내기 위해서 배열을 사용하였습니다. 배열을 사용한다면 잘못된 인덱스를 사용한다면 예외가 발생할 수 있다는 가능성이 존재하는 것을 제거하고 싶었습니다. 그리고 체스에서는 위치를 나타낼 때, 1 ~ 8, a ~ h 기호를 활용해서 나타냅니다. 이 위치 정보는 어느 게임이든지 변하지 않는 상수라고 생각하게 되었습니다. 이 두가지 생각으로 인해서 File, Rank라는 위치 정보를 나타내는 enum을 사용해서 안전하게 체스판의 말을 조회하도록 구현하면 좋겠다는 생각이들어서 도입하게 되었습니다.