### PR TITLE
[seminchoi] step-3 체스판 초기화

### DIFF
--- a/src/main/java/wootecamp/chess/Board.java
+++ b/src/main/java/wootecamp/chess/Board.java
@@ -15,22 +15,25 @@ public class Board {
 
     private static final String EMPTY_RANK_MESSAGE = "........";
 
-
     private List<Pawn> whitePawns = new ArrayList<>();
     private List<Pawn> blackPawns = new ArrayList<>();
+    private boolean isInit = false;
 
     public void initialize() {
+        isInit = true;
         initializeWhitePawns();
         initializeBlackPawns();
     }
 
     private void initializeWhitePawns() {
+        whitePawns = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
             whitePawns.add(new Pawn(Pawn.WHITE_COLOR));
         }
     }
 
     private void initializeBlackPawns() {
+        blackPawns = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
             blackPawns.add(new Pawn(Pawn.BLACK_COLOR));
         }
@@ -50,5 +53,32 @@ public class Board {
             result.append(blackPawns.get(i).getRepresentation());
         }
         return result.toString();
+    }
+
+
+    public String getBoardState() {
+        if(!isInit) {
+            throw new IllegalStateException("아직 보드가 초기화되지 않았습니다.");
+        }
+
+        StringBuilder builder = new StringBuilder();
+        int finalRank = 1;
+        for (int rank = BOARD_SIZE; rank > 0; rank--) {
+            builder.append(getRankState(rank));
+            if(rank > finalRank) {
+                builder.append("\n");
+            }
+        }
+        return builder.toString();
+    }
+
+    private String getRankState(int rank) {
+        if(rank == WHITE_PAWN_INIT_RANK) {
+            return getInitialStateWhitePawnResult();
+        }
+        if(rank == BLACK_PAWN_INIT_RANK) {
+            return getInitialStateBlackPawnResult();
+        }
+        return EMPTY_RANK_MESSAGE;
     }
 }

--- a/src/main/java/wootecamp/chess/Board.java
+++ b/src/main/java/wootecamp/chess/Board.java
@@ -3,20 +3,52 @@ package wootecamp.chess;
 import wootecamp.chess.pieces.Pawn;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public class Board {
-    private List<Pawn> pawns = new ArrayList<>();
+    private static final int BOARD_SIZE = 8;
+    private static final int WHITE_PAWN_INIT_RANK = 2;
+    private static final int BLACK_PAWN_INIT_RANK = 7;
 
-    public void add(Pawn pawn) {
-        pawns.add(pawn);
+    private static final String EMPTY_RANK_MESSAGE = "........";
+
+
+    private List<Pawn> whitePawns = new ArrayList<>();
+    private List<Pawn> blackPawns = new ArrayList<>();
+
+    public void initialize() {
+        initializeWhitePawns();
+        initializeBlackPawns();
     }
 
-    public int size() {
-        return pawns.size();
+    private void initializeWhitePawns() {
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            whitePawns.add(new Pawn(Pawn.WHITE_COLOR));
+        }
     }
 
-    public Pawn findPawn(int index) {
-        return pawns.get(index);
+    private void initializeBlackPawns() {
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            blackPawns.add(new Pawn(Pawn.BLACK_COLOR));
+        }
+    }
+
+    public String getInitialStateWhitePawnResult() {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            result.append(whitePawns.get(i).getRepresentation());
+        }
+        return result.toString();
+    }
+
+    public String getInitialStateBlackPawnResult() {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            result.append(blackPawns.get(i).getRepresentation());
+        }
+        return result.toString();
     }
 }

--- a/src/main/java/wootecamp/chess/Main.java
+++ b/src/main/java/wootecamp/chess/Main.java
@@ -1,0 +1,30 @@
+package wootecamp.chess;
+
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Board board = new Board();
+        Scanner sc = new Scanner(System.in);
+
+        while(true) {
+            String command = sc.next();
+
+            if(command.equals("start")) {
+                start(board);
+                continue;
+            }
+            if(command.equals("end")) {
+                break;
+            }
+
+            throw new IllegalArgumentException("잘못된 입력입니다.");
+        }
+    }
+
+    private static void start(Board board) {
+        board.initialize();
+        System.out.println(board.getBoardState());
+    }
+
+}

--- a/src/main/java/wootecamp/chess/pieces/Pawn.java
+++ b/src/main/java/wootecamp/chess/pieces/Pawn.java
@@ -2,19 +2,38 @@ package wootecamp.chess.pieces;
 
 public class Pawn {
     public static final String WHITE_COLOR = "white";
+    public static final String WHITE_REPRESENTATION = "p";
     public static final String BLACK_COLOR = "black";
+    public static final String BLACK_REPRESENTATION = "P";
 
     private String color;
+    private String representation;
 
     public Pawn() {
         this.color = WHITE_COLOR;
+        this.representation = WHITE_REPRESENTATION;
     }
 
     public Pawn(final String color) {
         this.color = color;
+        this.representation = decideRepresentation(color);
+    }
+
+    private String decideRepresentation(final String color) {
+        if(color.equals(WHITE_COLOR)) {
+            return WHITE_REPRESENTATION;
+        }
+        if(color.equals(BLACK_COLOR)) {
+            return BLACK_REPRESENTATION;
+        }
+        throw new IllegalArgumentException("잘못된 색상 전달");
     }
 
     public String getColor() {
         return color;
+    }
+
+    public String getRepresentation() {
+        return representation;
     }
 }

--- a/src/test/java/wootecamp/chess/BoardTest.java
+++ b/src/test/java/wootecamp/chess/BoardTest.java
@@ -22,4 +22,28 @@ public class BoardTest {
         assertThat(board.getInitialStateWhitePawnResult()).isEqualTo("pppppppp");
         assertThat(board.getInitialStateBlackPawnResult()).isEqualTo("PPPPPPPP");
     }
+
+    @Test
+    @DisplayName("체스판 초기 상태를 확인한다.")
+    void getBoardState() {
+        final String emptyRank = "........";
+        final String whitePawnRank = "pppppppp";
+        final String blackPawnRank = "PPPPPPPP";
+        final String newLine = "\n";
+
+        board.initialize();
+
+        String expectedState = emptyRank + newLine +
+                blackPawnRank + newLine +
+                emptyRank + newLine +
+                emptyRank + newLine +
+                emptyRank + newLine +
+                emptyRank + newLine +
+                whitePawnRank + newLine +
+                emptyRank;
+
+        String initBoardState = board.getBoardState();
+        System.out.println(initBoardState);
+        assertThat(initBoardState).isEqualTo(expectedState);
+    }
 }

--- a/src/test/java/wootecamp/chess/BoardTest.java
+++ b/src/test/java/wootecamp/chess/BoardTest.java
@@ -3,7 +3,6 @@ package wootecamp.chess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import wootecamp.chess.pieces.Pawn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,18 +16,10 @@ public class BoardTest {
     }
 
     @Test
-    @DisplayName("체스판을 생성한다.")
-    void create() {
-        Pawn whitePawn = new Pawn(Pawn.WHITE_COLOR);
-        verifyAddPawn(whitePawn, 1, 0);
-
-        Pawn blackPawn = new Pawn(Pawn.BLACK_COLOR);
-        verifyAddPawn(blackPawn, 2, 1);
-    }
-
-    void verifyAddPawn(Pawn pawn, int expectedBoardSize, int pawnIndex) {
-        board.add(pawn);
-        assertThat(board.size()).isEqualTo(expectedBoardSize);
-        assertThat(board.findPawn(pawnIndex)).isEqualTo(pawn);
+    @DisplayName("체스판을 초기화한다.")
+    void initialize() {
+        board.initialize();
+        assertThat(board.getInitialStateWhitePawnResult()).isEqualTo("pppppppp");
+        assertThat(board.getInitialStateBlackPawnResult()).isEqualTo("PPPPPPPP");
     }
 }

--- a/src/test/java/wootecamp/chess/pieces/PawnTest.java
+++ b/src/test/java/wootecamp/chess/pieces/PawnTest.java
@@ -10,13 +10,14 @@ public class PawnTest {
     @Test
     @DisplayName("생성자 파라미터에 색깔을 전달해서 폰을 생성한다.")
     void create() {
-        verifyPawn(Pawn.WHITE_COLOR);
-        verifyPawn(Pawn.BLACK_COLOR);
+        verifyPawn(Pawn.WHITE_COLOR, Pawn.WHITE_REPRESENTATION);
+        verifyPawn(Pawn.BLACK_COLOR, Pawn.BLACK_REPRESENTATION);
     }
 
-    void verifyPawn(final String color) {
+    void verifyPawn(final String color, final String representation) {
         final Pawn pawn = new Pawn(color);
         assertThat(pawn.getColor()).isEqualTo(color);
+        assertThat(pawn.getRepresentation()).isEqualTo(representation);
     }
 
     @Test
@@ -24,5 +25,6 @@ public class PawnTest {
     void create_defaultConstructor() {
         Pawn pawn = new Pawn();
         assertThat(pawn.getColor()).isEqualTo(Pawn.WHITE_COLOR);
+        assertThat(pawn.getRepresentation()).isEqualTo(Pawn.WHITE_REPRESENTATION);
     }
 }


### PR DESCRIPTION
## 구현 내용
- `Board` 초기화, 상태반환 메소드 구현
  - 기물을 구현한 클래스가 `Pawn` 클래스 밖에 없으므로 우선 `blackPawn`과 `whitePawn` 멤버변수 및 Rank 를 상수로 선언하여 구현
  - 현재 상태를 문자열로 반환하는 메소드 구현

## 고민 사항
- 왜 `Board`와 `BoardTest`의 기능을 전면 수정하는 일이 생겼는가?
  - 요구사항을 점진적으로 개발중인데, 전체적인 요구사항을 고려하지 않았음. 즉, 확장성을 고려하지 않고 Pawn을 Board에 추가하는 형태로 구현되었기 때문.
  - 마찬가지로 기물의 위치 정보를 구현한 후에는 `getWhitePawnResult()` 메소드는 추후 사용되지 않거나 변경될 가능성이 높음.  혹시라도 계속해서 사용될 가능성을 고려해  `getInitalStateWhitePawnResult()` 라는 메소드 네이밍을 사용하는 것이 더 좋아보임.

## 기타
- 이론으로만 알고있었지만 테스트를 통해 확인한 결과 작은 크기의 배열 순회에서는 Stream보다 for loop의 성능이 훨씬 좋다는 것을 검증했다!