### PR TITLE
[hek-git] step-2 체스판 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ bin/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+/.idea/uiDesigner.xml

--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -1,0 +1,21 @@
+import java.util.ArrayList;
+import java.util.List;
+
+public class Board {
+
+    private int size;
+    private final List<Pawn> pawns = new ArrayList<>();
+
+    public void add(Pawn pawn){
+        pawns.add(pawn);
+        size++;
+    }
+
+    public int size(){
+        return this.size;
+    }
+
+    public Pawn findPawn(int idx) {
+        return pawns.get(idx);
+    }
+}

--- a/src/main/java/Pawn.java
+++ b/src/main/java/Pawn.java
@@ -1,7 +1,7 @@
 public class Pawn {
 
-    private static final String BLACK = "black";
-    private static final String WHITE = "white";
+    public static final String BLACK_COLOR = "black";
+    public static final String WHITE_COLOR = "white";
 
     private String color;
 
@@ -10,7 +10,7 @@ public class Pawn {
     }
 
     public Pawn() {
-        this.color = Pawn.WHITE;
+        this.color = Pawn.WHITE_COLOR;
     }
 
     public String getColor() {

--- a/src/main/java/Pawn.java
+++ b/src/main/java/Pawn.java
@@ -6,6 +6,10 @@ public class Pawn {
         this.color = color;
     }
 
+    public Pawn() {
+        this.color = "white";
+    }
+
     public String getColor() {
         return this.color;
     }

--- a/src/main/java/Pawn.java
+++ b/src/main/java/Pawn.java
@@ -1,5 +1,8 @@
 public class Pawn {
 
+    private static final String BLACK = "black";
+    private static final String WHITE = "white";
+
     private String color;
 
     public Pawn(String color) {
@@ -7,7 +10,7 @@ public class Pawn {
     }
 
     public Pawn() {
-        this.color = "white";
+        this.color = Pawn.WHITE;
     }
 
     public String getColor() {

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -1,3 +1,7 @@
+package chess;
+
+import chess.pieces.Pawn;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -7,16 +7,14 @@ import java.util.List;
 
 public class Board {
 
-    private int size;
     private final List<Pawn> pawns = new ArrayList<>();
 
     public void add(Pawn pawn){
         pawns.add(pawn);
-        size++;
     }
 
-    public int size(){
-        return this.size;
+    public int size() {
+        return pawns.size();
     }
 
     public Pawn findPawn(int idx) {

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -1,3 +1,5 @@
+package chess.pieces;
+
 public class Pawn {
 
     public static final String BLACK_COLOR = "black";

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -1,0 +1,21 @@
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BoardTest {
+
+    @Test
+    public void create() throws Exception {
+        Board board = new Board();
+
+        Pawn white = new Pawn(Pawn.WHITE_COLOR);
+        board.add(white);
+        assertEquals(1, board.size());
+        assertEquals(white, board.findPawn(0));
+
+        Pawn black = new Pawn(Pawn.BLACK_COLOR);
+        board.add(black);
+        assertEquals(2, board.size());
+        assertEquals(black, board.findPawn(1));
+    }
+}

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -6,18 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BoardTest {
 
-    @Test
-    public void create() throws Exception {
-        Board board = new Board();
+    public static Board board;
 
-        Pawn white = new Pawn(Pawn.WHITE_COLOR);
-        board.add(white);
-        assertEquals(1, board.size());
-        assertEquals(white, board.findPawn(0));
-
-        Pawn black = new Pawn(Pawn.BLACK_COLOR);
-        board.add(black);
-        assertEquals(2, board.size());
-        assertEquals(black, board.findPawn(1));
+    @BeforeAll
+    static void setBoard(){
+        board = new Board();
     }
+
+    @Test
+    @DisplayName("보드에 폰이 추가 되어야한다.")
+    public void create() throws Exception {
+        verifyBoard(Pawn.BLACK_COLOR);
+        verifyBoard(Pawn.WHITE_COLOR);
+    }
+
+    private void verifyBoard(final String color) {
+        Pawn pawn = new Pawn(color);
+        board.add(pawn);
+        assertEquals(pawn, board.findPawn(board.size() - 1));
+    }
+
 }

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -1,3 +1,5 @@
+import chess.Board;
+import chess.pieces.Pawn;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/PawnTest.java
+++ b/src/test/java/PawnTest.java
@@ -1,3 +1,4 @@
+import chess.pieces.Pawn;
 import org.junit.jupiter.api.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/PawnTest.java
+++ b/src/test/java/PawnTest.java
@@ -6,19 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PawnTest {
 
     @Test
-    @DisplayName("흰색 폰이 생성되어야 한다.")
+    @DisplayName("흰색 폰, 검은색 폰이 생성되어야 한다.")
     public void create(){
-        String black = "black";
-        String white = "white";
-
-        verifyPawn(black);
-        verifyPawn(white);
+        verifyPawn(Pawn.BLACK_COLOR);
+        verifyPawn(Pawn.WHITE_COLOR);
     }
 
     @Test
+    @DisplayName("흰색 폰이 생성되어야 한다.")
     public void create_기본생성자() throws Exception {
         Pawn pawn = new Pawn();
-        assertEquals("white", pawn.getColor());
+        assertEquals(Pawn.WHITE_COLOR, pawn.getColor());
     }
 
     private void verifyPawn(final String color) {

--- a/src/test/java/PawnTest.java
+++ b/src/test/java/PawnTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PawnTest {
 
@@ -11,6 +12,12 @@ public class PawnTest {
 
         verifyPawn(black);
         verifyPawn(white);
+    }
+
+    @Test
+    public void create_기본생성자() throws Exception {
+        Pawn pawn = new Pawn();
+        assertEquals("white", pawn.getColor());
     }
 
     private void verifyPawn(final String color) {


### PR DESCRIPTION
## 구현 내용
- BoardTest 추가
  - Board 클래스 추가를 위한 BoardTest 클래스 추가
  - Pawn 생성 후 board에 추가하는 create 메서드 구현
-  Pawn 클래스 리팩토링
  - Pawn 색 관련 상수명 변경
- Board 클래스 구현
  - Pawn을 추가하는 add 메서드 구현
  - 현재 board 위의 Pawn 개수를 반환하는 size 메서드 구현
  - Pawn 번호를 이용해 Pawn 찾는 findPawn 메서드 구현
- 패키지 분리
  - 구현된 클래스, 테스트 클래스 패키지 분리
- 리팩토링(중복 제거)
  -  BoardTest 클래스의 폰 추가 로직을 메서드로 분리
  -  PawnTest의 색깔 -> Pawn 클래스의 전역 변수 사용
  - @BeforeAll 애노테이션으로 board 세팅

## 고민 사항
- 중복 제거를 어디에 적용해야할지 상당한 고민이 되었다. 결론적으로 Pawn을 보드에 추가하고 확인하는 부분이 반복되므로  
   폰을 보드에 추가하고 확인하는 로직으로 메서드를 분리하였다.
- board도 결국 BoardTest 내에서 공유되므로 @BeforeAll 애너테이션을 사용하여 모든 테스트 전에 Board를 주입하였다.
