### PR TITLE
[Hyeon-Uk] step-5 기물 위치 부여 및 점수계산

### DIFF
--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -34,17 +34,25 @@ public class Board {
         return pieces.get(index);
     }
 
-    public ChessPiece findPiece(String position){
+    private int getCol(String position){
         if(position == null || position.length() > 2) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
         char col = position.charAt(0);
+        if(!('a'<=col && col<='h')) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
+        return col-'a';
+    }
+
+    private int getRow(String position){
+        if(position == null || position.length() > 2) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
         char row = position.charAt(1);
 
-        if(!('a'<=col && col<='h') || !('1'<=row&&row<='8')) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
+        if(!('1'<=row&&row<='8')) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
+        return row-'1';
+    }
 
-        int colIndex = col-'a';
-        int rowIndex = row-'1';
-
-        return board[rowIndex][colIndex];
+    public ChessPiece findPiece(String position){
+        int row = getRow(position);
+        int col = getCol(position);
+        return board[row][col];
     }
 
     public int pieceCount(){

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -2,7 +2,6 @@ package chess;
 
 import chess.pieces.ChessPiece;
 import chess.pieces.Piece;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +32,27 @@ public class Board {
 
     public ChessPiece findPiece(int index){
         return pieces.get(index);
+    }
+
+    public ChessPiece findPiece(String position){
+        if(position == null || position.length() > 2) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
+        char col = position.charAt(0);
+        char row = position.charAt(1);
+
+        if(!('a'<=col && col<='h') || !('1'<=row&&row<='8')) throw new IllegalArgumentException("position은 a1 ~ h8 까지 입력해주세요");
+
+        int colIndex = col-'a';
+        int rowIndex = row-'1';
+
+        return board[rowIndex][colIndex];
+    }
+
+    public int pieceCount(){
+        return Arrays.stream(board)
+                .flatMap(Arrays::stream)
+                .filter(p->p!=null&&!Type.NO_PIECE.equals(p.getType()))
+                .toList()
+                .size();
     }
 
     private void setPiece(int x,int y,ChessPiece piece){

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -119,6 +119,14 @@ public class Board {
         }
     }
 
+    public void initializeEmpty(){
+        for(int h=0;h<HEIGHT;h++){
+            for(int w=0;w<WIDTH;w++){
+                board[h][w] = Piece.createPiece(NO_PIECE);
+            }
+        }
+    }
+
     public String print(){
         StringBuilder sb = new StringBuilder();
         for(int h=HEIGHT-1;h>=0;h--){

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -49,6 +49,10 @@ public class Board {
         return row-'1';
     }
 
+    private boolean isIn(int x,int y){
+        return 0<=x&&x<HEIGHT&&0<=y&&y<WIDTH;
+    }
+
     public ChessPiece findPiece(String position){
         int row = getRow(position);
         int col = getCol(position);
@@ -64,7 +68,7 @@ public class Board {
     }
 
     private void setPiece(int x,int y,ChessPiece piece){
-        if(x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT) throw new IllegalArgumentException("범위 안의 좌표를 입력해주세요");
+        if(!isIn(x,y)) throw new IllegalArgumentException("범위 안의 좌표를 입력해주세요");
         board[x][y] = piece;
     }
 
@@ -170,5 +174,29 @@ public class Board {
                 .flatMap(Arrays::stream)
                 .filter(p->p!=null&&color.equals(p.getColor())&&type.equals(p.getType()))
                 .toList().size();
+    }
+
+    public double calculatePoint(Color color){
+        double sum = 0.0;
+        for(int h=0;h<HEIGHT;h++){
+            for(int w=0;w<WIDTH;w++){
+                Color c = board[h][w].getColor();
+                Type t = board[h][w].getType();
+
+                if(color.equals(c)){
+                    if(Type.PAWN.equals(t) && hasPawnVertically(h,w)){
+                        sum+=0.5;
+                    }
+                    else{
+                        sum+=t.getPoint();
+                    }
+                }
+            }
+        }
+        return sum;
+    }
+
+    private boolean hasPawnVertically(int x,int y){
+        return (isIn(x+1,y) && Type.PAWN.equals(board[x+1][y].getType()) || isIn(x-1,y) && Type.PAWN.equals(board[x-1][y].getType()));
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -135,6 +135,25 @@ public class Board {
         }
     }
 
+    private void removePiece(ChessPiece piece){
+        for(int h=0;h<HEIGHT;h++){
+            for(int w=0;w<WIDTH;w++){
+                if(board[h][w].equals(piece)){
+                    board[h][w] = Piece.createPiece(NO_PIECE);
+                    return;
+                }
+            }
+        }
+    }
+
+    public void move(String position,ChessPiece piece){
+        removePiece(piece);
+        int row = getRow(position);
+        int col = getCol(position);
+
+        board[row][col] = piece;
+    }
+
     public String print(){
         StringBuilder sb = new StringBuilder();
         for(int h=HEIGHT-1;h>=0;h--){

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -4,6 +4,7 @@ import chess.pieces.ChessPiece;
 import chess.pieces.Piece;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static chess.pieces.PieceTypes.*;
@@ -107,5 +108,12 @@ public class Board {
             sb.append('\n');
         }
         return sb.toString();
+    }
+
+    public int findPieceWithColorAndType(Color color,Type type){
+        return Arrays.stream(board)
+                .flatMap(Arrays::stream)
+                .filter(p->p!=null&&color.equals(p.getColor())&&type.equals(p.getType()))
+                .toList().size();
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -2,10 +2,11 @@ package chess;
 
 import chess.pieces.ChessPiece;
 import chess.pieces.Piece;
-import chess.pieces.PieceTypes;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static chess.pieces.PieceTypes.*;
 
 public class Board {
     private final int WIDTH = 8;
@@ -42,51 +43,60 @@ public class Board {
     public void initialize(){
         //pawn 셋팅
         for(int w=0;w<WIDTH;w++){
-            Piece whitePawn = Piece.createPiece(PieceTypes.WHITE_PAWN);
-            Piece blackPawn = Piece.createPiece(PieceTypes.BLACK_PAWN);
+            Piece whitePawn = Piece.createPiece(WHITE_PAWN);
+            Piece blackPawn = Piece.createPiece(BLACK_PAWN);
             setPiece(WHITE_PAWN_START_LINE,w,whitePawn);
             setPiece(BLACK_PAWN_START_LINE,w,blackPawn);
         }
 
         //rook 셋팅
-        Piece whiteRookLeft = Piece.createPiece(PieceTypes.WHITE_ROOK);
-        Piece whiteRookRight = Piece.createPiece(PieceTypes.WHITE_ROOK);
-        Piece blackRookLeft = Piece.createPiece(PieceTypes.BLACK_ROOK);
-        Piece blackRookRight = Piece.createPiece(PieceTypes.BLACK_ROOK);
+        Piece whiteRookLeft = Piece.createPiece(WHITE_ROOK);
+        Piece whiteRookRight = Piece.createPiece(WHITE_ROOK);
+        Piece blackRookLeft = Piece.createPiece(BLACK_ROOK);
+        Piece blackRookRight = Piece.createPiece(BLACK_ROOK);
         setPiece(BLACK_START_LINE,0,blackRookLeft);
         setPiece(BLACK_START_LINE,WIDTH-1,blackRookRight);
         setPiece(WHITE_START_LINE,0,whiteRookLeft);
         setPiece(WHITE_START_LINE,WIDTH-1,whiteRookRight);
 
         //night 셋팅
-        Piece whiteNightLeft = Piece.createPiece(PieceTypes.WHITE_KNIGHT);
-        Piece whiteNightRight = Piece.createPiece(PieceTypes.WHITE_KNIGHT);
-        Piece blackNightLeft = Piece.createPiece(PieceTypes.BLACK_KNIGHT);
-        Piece blackNightRight = Piece.createPiece(PieceTypes.BLACK_KNIGHT);
+        Piece whiteNightLeft = Piece.createPiece(WHITE_KNIGHT);
+        Piece whiteNightRight = Piece.createPiece(WHITE_KNIGHT);
+        Piece blackNightLeft = Piece.createPiece(BLACK_KNIGHT);
+        Piece blackNightRight = Piece.createPiece(BLACK_KNIGHT);
         setPiece(BLACK_START_LINE,1,blackNightLeft);
         setPiece(BLACK_START_LINE,WIDTH-2,blackNightRight);
         setPiece(WHITE_START_LINE,1,whiteNightLeft);
         setPiece(WHITE_START_LINE,WIDTH-2,whiteNightRight);
 
         //bishop 셋팅
-        Piece whiteBishopLeft = Piece.createPiece(PieceTypes.WHITE_BISHOP);
-        Piece whiteBishopRight = Piece.createPiece(PieceTypes.WHITE_BISHOP);
-        Piece blackBishopLeft = Piece.createPiece(PieceTypes.BLACK_BISHOP);
-        Piece blackBishopRight = Piece.createPiece(PieceTypes.BLACK_BISHOP);
+        Piece whiteBishopLeft = Piece.createPiece(WHITE_BISHOP);
+        Piece whiteBishopRight = Piece.createPiece(WHITE_BISHOP);
+        Piece blackBishopLeft = Piece.createPiece(BLACK_BISHOP);
+        Piece blackBishopRight = Piece.createPiece(BLACK_BISHOP);
         setPiece(BLACK_START_LINE,2,blackBishopLeft);
         setPiece(BLACK_START_LINE,WIDTH-3,blackBishopRight);
         setPiece(WHITE_START_LINE,2,whiteBishopLeft);
         setPiece(WHITE_START_LINE,WIDTH-3,whiteBishopRight);
 
         //queen & king setting
-        Piece whiteQueen = Piece.createPiece(PieceTypes.WHITE_QUEEN);
-        Piece whiteKing = Piece.createPiece(PieceTypes.WHITE_KING);
-        Piece blackQueen = Piece.createPiece(PieceTypes.BLACK_QUEEN);
-        Piece blackKing = Piece.createPiece(PieceTypes.BLACK_KING);
+        Piece whiteQueen = Piece.createPiece(WHITE_QUEEN);
+        Piece whiteKing = Piece.createPiece(WHITE_KING);
+        Piece blackQueen = Piece.createPiece(BLACK_QUEEN);
+        Piece blackKing = Piece.createPiece(BLACK_KING);
         setPiece(BLACK_START_LINE,3,blackQueen);
         setPiece(BLACK_START_LINE,WIDTH-4,blackKing);
         setPiece(WHITE_START_LINE,3,whiteQueen);
         setPiece(WHITE_START_LINE,WIDTH-4,whiteKing);
+
+        //아무것도 없는 칸들을 blank piece로 채우기
+        for(int x=0;x<HEIGHT;x++){
+            for(int y=0;y<WIDTH;y++){
+                if(board[x][y] == null){
+                    board[x][y] = Piece.createPiece(NO_PIECE);
+                }
+            }
+        }
     }
 
     public String print(){

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -196,6 +196,14 @@ public class Board {
         return sum;
     }
 
+    public List<ChessPiece> getPieceOrderByPoint(Color color,boolean isAsc){
+        return Arrays.stream(board)
+                .flatMap(Arrays::stream)
+                .filter(c->color.equals(c.getColor()))
+                .sorted((o1,o2)-> isAsc ? Double.compare(o1.getType().getPoint(),o2.getType().getPoint()) : Double.compare(o2.getType().getPoint(),o1.getType().getPoint()))
+                .toList();
+    }
+
     private boolean hasPawnVertically(int x,int y){
         return (isIn(x+1,y) && Type.PAWN.equals(board[x+1][y].getType()) || isIn(x-1,y) && Type.PAWN.equals(board[x-1][y].getType()));
     }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -10,6 +10,10 @@ import java.util.List;
 public class Board {
     private final int WIDTH = 8;
     private final int HEIGHT = 8;
+    private final int WHITE_START_LINE = 0;
+    private final int WHITE_PAWN_START_LINE = WHITE_START_LINE+1;
+    private final int BLACK_START_LINE = HEIGHT-1;
+    private final int BLACK_PAWN_START_LINE = BLACK_START_LINE-1;
     private List<ChessPiece> pieces;
     private ChessPiece[][] board;
     public Board(){
@@ -40,8 +44,8 @@ public class Board {
         for(int w=0;w<WIDTH;w++){
             Piece whitePawn = Piece.createPiece(PieceTypes.WHITE_PAWN);
             Piece blackPawn = Piece.createPiece(PieceTypes.BLACK_PAWN);
-            setPiece(HEIGHT-2,w,whitePawn);
-            setPiece(1,w,blackPawn);
+            setPiece(WHITE_PAWN_START_LINE,w,whitePawn);
+            setPiece(BLACK_PAWN_START_LINE,w,blackPawn);
         }
 
         //rook 셋팅
@@ -49,45 +53,45 @@ public class Board {
         Piece whiteRookRight = Piece.createPiece(PieceTypes.WHITE_ROOK);
         Piece blackRookLeft = Piece.createPiece(PieceTypes.BLACK_ROOK);
         Piece blackRookRight = Piece.createPiece(PieceTypes.BLACK_ROOK);
-        setPiece(0,0,blackRookLeft);
-        setPiece(0,WIDTH-1,blackRookRight);
-        setPiece(HEIGHT-1,0,whiteRookLeft);
-        setPiece(HEIGHT-1,WIDTH-1,whiteRookRight);
+        setPiece(BLACK_START_LINE,0,blackRookLeft);
+        setPiece(BLACK_START_LINE,WIDTH-1,blackRookRight);
+        setPiece(WHITE_START_LINE,0,whiteRookLeft);
+        setPiece(WHITE_START_LINE,WIDTH-1,whiteRookRight);
 
         //night 셋팅
         Piece whiteNightLeft = Piece.createPiece(PieceTypes.WHITE_KNIGHT);
         Piece whiteNightRight = Piece.createPiece(PieceTypes.WHITE_KNIGHT);
         Piece blackNightLeft = Piece.createPiece(PieceTypes.BLACK_KNIGHT);
         Piece blackNightRight = Piece.createPiece(PieceTypes.BLACK_KNIGHT);
-        setPiece(0,1,blackNightLeft);
-        setPiece(0,WIDTH-2,blackNightRight);
-        setPiece(HEIGHT-1,1,whiteNightLeft);
-        setPiece(HEIGHT-1,WIDTH-2,whiteNightRight);
+        setPiece(BLACK_START_LINE,1,blackNightLeft);
+        setPiece(BLACK_START_LINE,WIDTH-2,blackNightRight);
+        setPiece(WHITE_START_LINE,1,whiteNightLeft);
+        setPiece(WHITE_START_LINE,WIDTH-2,whiteNightRight);
 
         //bishop 셋팅
         Piece whiteBishopLeft = Piece.createPiece(PieceTypes.WHITE_BISHOP);
         Piece whiteBishopRight = Piece.createPiece(PieceTypes.WHITE_BISHOP);
         Piece blackBishopLeft = Piece.createPiece(PieceTypes.BLACK_BISHOP);
         Piece blackBishopRight = Piece.createPiece(PieceTypes.BLACK_BISHOP);
-        setPiece(0,2,blackBishopLeft);
-        setPiece(0,WIDTH-3,blackBishopRight);
-        setPiece(HEIGHT-1,2,whiteBishopLeft);
-        setPiece(HEIGHT-1,WIDTH-3,whiteBishopRight);
+        setPiece(BLACK_START_LINE,2,blackBishopLeft);
+        setPiece(BLACK_START_LINE,WIDTH-3,blackBishopRight);
+        setPiece(WHITE_START_LINE,2,whiteBishopLeft);
+        setPiece(WHITE_START_LINE,WIDTH-3,whiteBishopRight);
 
         //queen & king setting
         Piece whiteQueen = Piece.createPiece(PieceTypes.WHITE_QUEEN);
         Piece whiteKing = Piece.createPiece(PieceTypes.WHITE_KING);
         Piece blackQueen = Piece.createPiece(PieceTypes.BLACK_QUEEN);
         Piece blackKing = Piece.createPiece(PieceTypes.BLACK_KING);
-        setPiece(0,3,blackQueen);
-        setPiece(0,WIDTH-4,blackKing);
-        setPiece(HEIGHT-1,3,whiteQueen);
-        setPiece(HEIGHT-1,WIDTH-4,whiteKing);
+        setPiece(BLACK_START_LINE,3,blackQueen);
+        setPiece(BLACK_START_LINE,WIDTH-4,blackKing);
+        setPiece(WHITE_START_LINE,3,whiteQueen);
+        setPiece(WHITE_START_LINE,WIDTH-4,whiteKing);
     }
 
     public String print(){
         StringBuilder sb = new StringBuilder();
-        for(int h=0;h<HEIGHT;h++){
+        for(int h=HEIGHT-1;h>=0;h--){
             for(int w=0;w<WIDTH;w++){
                 sb.append(board[h][w] == null ? '.' : board[h][w].getRepresentation());
             }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -36,7 +36,6 @@ public class Board {
 
     private void setPiece(int x,int y,ChessPiece piece){
         if(x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT) throw new IllegalArgumentException("범위 안의 좌표를 입력해주세요");
-        pieces.add(piece);
         board[x][y] = piece;
     }
 

--- a/src/main/java/chess/pieces/ChessPiece.java
+++ b/src/main/java/chess/pieces/ChessPiece.java
@@ -1,7 +1,7 @@
 package chess.pieces;
 
 public interface ChessPiece {
-    String getColor();
+    PieceTypes.Color getColor();
     char getRepresentation();
-    String getType();
+    PieceTypes.Type getType();
 }

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -1,15 +1,17 @@
 package chess.pieces;
 
+import static chess.pieces.PieceTypes.*;
+
 public class Piece implements ChessPiece {
-    private final String color;
+    private final Color color;
     private final char representation;
-    private final String type;
+    private final Type type;
 
     private Piece(PieceTypes values){
         this(values.getColor(),values.getRepresentation(),values.getType());
     }
 
-    private Piece(String color, char representation,String type) {
+    private Piece(Color color, char representation, Type type) {
         this.color = color;
         this.representation = representation;
         this.type = type;
@@ -19,7 +21,7 @@ public class Piece implements ChessPiece {
         return new Piece(piece);
     }
 
-    public String getColor() {
+    public Color getColor() {
         return color;
     }
 
@@ -27,15 +29,15 @@ public class Piece implements ChessPiece {
         return representation;
     }
 
-    public String getType() {
+    public Type getType() {
         return type;
     }
 
     public boolean isBlack(){
-        return "black".equals(this.color);
+        return Color.BLACK.equals(color);
     }
 
     public boolean isWhite(){
-        return "white".equals(this.color);
+        return Color.WHITE.equals(color);
     }
 }

--- a/src/main/java/chess/pieces/PieceTypes.java
+++ b/src/main/java/chess/pieces/PieceTypes.java
@@ -18,14 +18,25 @@ public enum PieceTypes {
         WHITE,BLACK,NOCOLOR;
     }
     public enum Type{
-        PAWN('p'),ROOK('r'),KNIGHT('n'),BISHOP('b'),QUEEN('q'),KING('k'),NO_PIECE('.');
+        PAWN('p',1.0),
+        ROOK('r',5.0),
+        KNIGHT('n',2.5),
+        BISHOP('b',3.0),
+        QUEEN('q',9.0),
+        KING('k',0.0)
+        ,NO_PIECE('.',0.0);
         private final char representation;
-        Type(char representation){
+        private final double point;
+        Type(char representation,double point){
             this.representation = representation;
+            this.point = point;
         }
 
         public char getRepresentation(){
             return this.representation;
+        }
+        public double getPoint(){
+            return this.point;
         }
     }
 
@@ -33,12 +44,14 @@ public enum PieceTypes {
     private final Color color;
     private final Type type;
     private final char representation;
+    private final double point;
 
     PieceTypes(Color color, Type type) {
         this.color = color;
         this.type = type;
-        char representation = this.type.getRepresentation();
+        char representation = type.getRepresentation();
         this.representation = color.equals(Color.WHITE) ? representation : Character.toUpperCase(representation);
+        this.point = type.getPoint();
     }
 
     public Color getColor() {
@@ -51,5 +64,9 @@ public enum PieceTypes {
 
     public char getRepresentation() {
         return representation;
+    }
+
+    public double getPoint(){
+        return point;
     }
 }

--- a/src/main/java/chess/pieces/PieceTypes.java
+++ b/src/main/java/chess/pieces/PieceTypes.java
@@ -1,35 +1,51 @@
 package chess.pieces;
 
 public enum PieceTypes {
-    WHITE_PAWN("white","pawn",'p'),
-    BLACK_PAWN("black","pawn",'P'),
-    WHITE_KNIGHT("white","knight",'n'),
-    BLACK_KNIGHT("black","knight",'N'),
-    WHITE_ROOK("white","rook",'r'),
-    BLACK_ROOK("black","rook",'R'),
-    WHITE_BISHOP("white","bishop",'b'),
-    BLACK_BISHOP("black","bishop",'B'),
-    WHITE_QUEEN("white","queen",'q'),
-    BLACK_QUEEN("black","queen",'Q'),
-    WHITE_KING("white","king",'k'),
-    BLACK_KING("black","king",'K'),
+    WHITE_PAWN(Color.WHITE,Type.PAWN),
+    BLACK_PAWN(Color.BLACK,Type.PAWN),
+    WHITE_KNIGHT(Color.WHITE,Type.KNIGHT),
+    BLACK_KNIGHT(Color.BLACK,Type.KNIGHT),
+    WHITE_ROOK(Color.WHITE,Type.ROOK),
+    BLACK_ROOK(Color.BLACK,Type.ROOK),
+    WHITE_BISHOP(Color.WHITE,Type.BISHOP),
+    BLACK_BISHOP(Color.BLACK,Type.BISHOP),
+    WHITE_QUEEN(Color.WHITE,Type.QUEEN),
+    BLACK_QUEEN(Color.BLACK,Type.QUEEN),
+    WHITE_KING(Color.WHITE,Type.KING),
+    BLACK_KING(Color.BLACK,Type.KING),
     ;
+    public enum Color{
+        WHITE,BLACK,NOCOLOR;
+    }
+    public enum Type{
+        PAWN('p'),ROOK('r'),KNIGHT('n'),BISHOP('b'),QUEEN('q'),KING('k'),NO_PIECE('.');
+        private final char representation;
+        Type(char representation){
+            this.representation = representation;
+        }
 
-    private final String color;
-    private final String type;
-    private final char representation;
-
-    PieceTypes(String color, String type, char representation) {
-        this.color = color;
-        this.type = type;
-        this.representation = representation;
+        public char getRepresentation(){
+            return this.representation;
+        }
     }
 
-    public String getColor() {
+
+    private final Color color;
+    private final Type type;
+    private final char representation;
+
+    PieceTypes(Color color, Type type) {
+        this.color = color;
+        this.type = type;
+        char representation = this.type.getRepresentation();
+        this.representation = color.equals(Color.WHITE) ? representation : Character.toUpperCase(representation);
+    }
+
+    public Color getColor() {
         return color;
     }
 
-    public String getType() {
+    public Type getType() {
         return type;
     }
 

--- a/src/main/java/chess/pieces/PieceTypes.java
+++ b/src/main/java/chess/pieces/PieceTypes.java
@@ -13,7 +13,7 @@ public enum PieceTypes {
     BLACK_QUEEN(Color.BLACK,Type.QUEEN),
     WHITE_KING(Color.WHITE,Type.KING),
     BLACK_KING(Color.BLACK,Type.KING),
-    ;
+    NO_PIECE(Color.NOCOLOR,Type.NO_PIECE);
     public enum Color{
         WHITE,BLACK,NOCOLOR;
     }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -2,6 +2,8 @@ package chess;
 
 import chess.pieces.Piece;
 import chess.pieces.PieceTypes;
+import chess.pieces.PieceTypes.Color;
+import chess.pieces.PieceTypes.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +42,24 @@ public class BoardTest {
                 pppppppp
                 rnbqkbnr
                 """,board.print());
+    }
+
+    @Test
+    public void findPieceWithColorAndTypeTest(){
+        board.initialize();
+
+        assertEquals(8,board.findPieceWithColorAndType(Color.BLACK, Type.PAWN));
+        assertEquals(8,board.findPieceWithColorAndType(Color.WHITE, Type.PAWN));
+        assertEquals(2,board.findPieceWithColorAndType(Color.BLACK,Type.KNIGHT));
+        assertEquals(2,board.findPieceWithColorAndType(Color.WHITE,Type.KNIGHT));
+        assertEquals(2,board.findPieceWithColorAndType(Color.BLACK,Type.ROOK));
+        assertEquals(2,board.findPieceWithColorAndType(Color.WHITE,Type.ROOK));
+        assertEquals(2,board.findPieceWithColorAndType(Color.BLACK,Type.BISHOP));
+        assertEquals(2,board.findPieceWithColorAndType(Color.WHITE,Type.BISHOP));
+        assertEquals(1,board.findPieceWithColorAndType(Color.BLACK,Type.QUEEN));
+        assertEquals(1,board.findPieceWithColorAndType(Color.WHITE,Type.QUEEN));
+        assertEquals(1,board.findPieceWithColorAndType(Color.BLACK,Type.KING));
+        assertEquals(1,board.findPieceWithColorAndType(Color.WHITE,Type.KING));
+
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -102,7 +102,7 @@ public class BoardTest {
     }
 
     @Test
-    public void caculcatePoint() throws Exception {
+    public void calculcatePoint() throws Exception {
         board.initializeEmpty();
 
         addPiece("b6", Piece.createPiece(BLACK_PAWN));
@@ -117,8 +117,31 @@ public class BoardTest {
 
         assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
         assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
+    }
 
-        System.out.println(board.print());
+    @Test
+    public void calculatePointTest2_verticalPawns(){
+        board.initializeEmpty();
+
+        addPiece("e1",Piece.createPiece(WHITE_ROOK));
+        addPiece("f1",Piece.createPiece(WHITE_KING));
+        addPiece("f2",Piece.createPiece(WHITE_PAWN));
+        addPiece("g2",Piece.createPiece(WHITE_PAWN));
+        addPiece("f3",Piece.createPiece(WHITE_PAWN));
+        addPiece("h3",Piece.createPiece(WHITE_PAWN));
+        addPiece("f4",Piece.createPiece(WHITE_KNIGHT));
+        addPiece("g4",Piece.createPiece(WHITE_QUEEN));
+
+        addPiece("b6",Piece.createPiece(BLACK_PAWN));
+        addPiece("e6",Piece.createPiece(BLACK_QUEEN));
+        addPiece("a7",Piece.createPiece(BLACK_PAWN));
+        addPiece("c7",Piece.createPiece(BLACK_PAWN));
+        addPiece("d7",Piece.createPiece(BLACK_BISHOP));
+        addPiece("b8",Piece.createPiece(BLACK_KING));
+        addPiece("c8",Piece.createPiece(BLACK_ROOK));
+
+        assertEquals(20.0,board.calculatePoint(Color.BLACK),0.01);
+        assertEquals(19.5,board.calculatePoint(Color.WHITE),0.01);
     }
 
     private void addPiece(String position, Piece piece) {

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -1,5 +1,6 @@
 package chess;
 
+import chess.pieces.ChessPiece;
 import chess.pieces.Piece;
 import chess.pieces.PieceTypes;
 import chess.pieces.PieceTypes.Color;
@@ -7,6 +8,8 @@ import chess.pieces.PieceTypes.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static chess.pieces.PieceTypes.BLACK_ROOK;
+import static chess.pieces.PieceTypes.WHITE_ROOK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BoardTest {
@@ -31,7 +34,7 @@ public class BoardTest {
     @Test
     public void print(){
         board.initialize();
-        assertEquals(32,board.size());
+        assertEquals(32,board.pieceCount());
         assertEquals("""
                 RNBQKBNR
                 PPPPPPPP
@@ -61,5 +64,28 @@ public class BoardTest {
         assertEquals(1,board.findPieceWithColorAndType(Color.BLACK,Type.KING));
         assertEquals(1,board.findPieceWithColorAndType(Color.WHITE,Type.KING));
 
+    }
+
+    @Test
+    public void findPieceWithPositionTest(){
+        //given
+        board.initialize();
+
+        //when
+        ChessPiece a8 = board.findPiece("a8");
+        ChessPiece h8 = board.findPiece("h8");
+        ChessPiece a1 = board.findPiece("a1");
+        ChessPiece h1 = board.findPiece("h1");
+
+        //then=
+        verifyPieceColorAndType(a8,BLACK_ROOK);
+        verifyPieceColorAndType(h8,BLACK_ROOK);
+        verifyPieceColorAndType(a1,WHITE_ROOK);
+        verifyPieceColorAndType(h1,WHITE_ROOK);
+    }
+
+    private void verifyPieceColorAndType(ChessPiece piece, PieceTypes pieceType){
+        assertEquals(pieceType.getColor(),piece.getColor());
+        assertEquals(pieceType.getType(),piece.getType());
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -8,6 +8,7 @@ import chess.pieces.PieceTypes.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static chess.pieces.PieceTypes.*;
@@ -142,6 +143,58 @@ public class BoardTest {
 
         assertEquals(20.0,board.calculatePoint(Color.BLACK),0.01);
         assertEquals(19.5,board.calculatePoint(Color.WHITE),0.01);
+    }
+
+    @Test
+    public void sortEachColorOrderByPointDesc(){
+        board.initializeEmpty();
+        addPiece("h3",Piece.createPiece(WHITE_PAWN));
+        addPiece("f4",Piece.createPiece(WHITE_KNIGHT));
+
+        addPiece("b6",Piece.createPiece(BLACK_PAWN));
+        addPiece("e6",Piece.createPiece(BLACK_QUEEN));
+
+        List<ChessPiece> blackOrderByPointDesc = board.getPieceOrderByPoint(Color.BLACK,false);
+        assertEquals(2,blackOrderByPointDesc.size());
+        assertEquals(Type.QUEEN,blackOrderByPointDesc.get(0).getType());
+        assertEquals(Color.BLACK,blackOrderByPointDesc.get(0).getColor());
+
+        assertEquals(Type.PAWN,blackOrderByPointDesc.get(1).getType());
+        assertEquals(Color.BLACK,blackOrderByPointDesc.get(1).getColor());
+
+        List<ChessPiece> whiteOrderByPointDesc = board.getPieceOrderByPoint(Color.WHITE,false);
+        assertEquals(2,whiteOrderByPointDesc.size());
+        assertEquals(Type.KNIGHT,whiteOrderByPointDesc.get(0).getType());
+        assertEquals(Color.WHITE,whiteOrderByPointDesc.get(0).getColor());
+
+        assertEquals(Type.PAWN,whiteOrderByPointDesc.get(1).getType());
+        assertEquals(Color.WHITE,whiteOrderByPointDesc.get(1).getColor());
+    }
+
+    @Test
+    public void sortEachColorOrderByPointAsc(){
+        board.initializeEmpty();
+        addPiece("h3",Piece.createPiece(WHITE_PAWN));
+        addPiece("f4",Piece.createPiece(WHITE_KNIGHT));
+
+        addPiece("b6",Piece.createPiece(BLACK_PAWN));
+        addPiece("e6",Piece.createPiece(BLACK_QUEEN));
+
+        List<ChessPiece> blackOrderByPointAsc = board.getPieceOrderByPoint(Color.BLACK,true);
+        assertEquals(2,blackOrderByPointAsc.size());
+        assertEquals(Type.PAWN,blackOrderByPointAsc.get(0).getType());
+        assertEquals(Color.BLACK,blackOrderByPointAsc.get(0).getColor());
+
+        assertEquals(Type.QUEEN,blackOrderByPointAsc.get(1).getType());
+        assertEquals(Color.BLACK,blackOrderByPointAsc.get(1).getColor());
+
+        List<ChessPiece> whiteOrderByPointAsc = board.getPieceOrderByPoint(Color.WHITE,true);
+        assertEquals(2,whiteOrderByPointAsc.size());
+        assertEquals(Type.PAWN,whiteOrderByPointAsc.get(0).getType());
+        assertEquals(Color.WHITE,whiteOrderByPointAsc.get(0).getColor());
+
+        assertEquals(Type.KNIGHT,whiteOrderByPointAsc.get(1).getType());
+        assertEquals(Color.WHITE,whiteOrderByPointAsc.get(1).getColor());
     }
 
     private void addPiece(String position, Piece piece) {

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -88,4 +88,16 @@ public class BoardTest {
         assertEquals(pieceType.getColor(),piece.getColor());
         assertEquals(pieceType.getType(),piece.getType());
     }
+
+    @Test
+    public void temp() throws Exception{
+        //given
+
+        //when
+        board.initializeEmpty();
+
+        //then
+        assertEquals(0,board.pieceCount());
+
+    }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -8,8 +8,9 @@ import chess.pieces.PieceTypes.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static chess.pieces.PieceTypes.BLACK_ROOK;
-import static chess.pieces.PieceTypes.WHITE_ROOK;
+import java.util.Optional;
+
+import static chess.pieces.PieceTypes.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BoardTest {
@@ -98,6 +99,29 @@ public class BoardTest {
 
         //then
         assertEquals(0,board.pieceCount());
+    }
 
+    @Test
+    public void caculcatePoint() throws Exception {
+        board.initializeEmpty();
+
+        addPiece("b6", Piece.createPiece(BLACK_PAWN));
+        addPiece("e6", Piece.createPiece(BLACK_QUEEN));
+        addPiece("b8", Piece.createPiece(BLACK_KING));
+        addPiece("c8", Piece.createPiece(BLACK_ROOK));
+
+        addPiece("f2", Piece.createPiece(WHITE_PAWN));
+        addPiece("g2", Piece.createPiece(WHITE_PAWN));
+        addPiece("e1", Piece.createPiece(WHITE_ROOK));
+        addPiece("f1", Piece.createPiece(WHITE_KING));
+
+        assertEquals(15.0, board.caculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.0, board.caculatePoint(Color.WHITE), 0.01);
+
+        System.out.println(board.print());
+    }
+
+    private void addPiece(String position, Piece piece) {
+        board.move(position, piece);
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -90,7 +90,7 @@ public class BoardTest {
     }
 
     @Test
-    public void temp() throws Exception{
+    public void initializeEmptytest() throws Exception{
         //given
 
         //when

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -115,8 +115,8 @@ public class BoardTest {
         addPiece("e1", Piece.createPiece(WHITE_ROOK));
         addPiece("f1", Piece.createPiece(WHITE_KING));
 
-        assertEquals(15.0, board.caculatePoint(Color.BLACK), 0.01);
-        assertEquals(7.0, board.caculatePoint(Color.WHITE), 0.01);
+        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
 
         System.out.println(board.print());
     }

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -100,4 +100,13 @@ public class PieceTest {
         assertFalse(whiteKing.isBlack());
         assertTrue(whiteKing.isWhite());
     }
+
+    @Test
+    public void createBlank(){
+        Piece blank = Piece.createPiece(NO_PIECE);
+
+        assertEquals(Type.NO_PIECE,blank.getType());
+        assertFalse(blank.isBlack());
+        assertFalse(blank.isWhite());
+    }
 }

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -10,7 +10,7 @@ public class PieceTest {
         verifyPiece(piece, type.getColor(), type.getRepresentation(), type.getType());
     }
 
-    private void verifyPiece(final Piece piece, final String color, final char representation, final String type) {
+    private void verifyPiece(final Piece piece, final Color color, final char representation, final Type type) {
         assertEquals(color, piece.getColor());
         assertEquals(representation, piece.getRepresentation());
         assertEquals(type, piece.getType());


### PR DESCRIPTION
## 구현 내용
체스판에 공백을 no-piece 타입의 기물로 채워넣어 null과 관련한 처리를 유연하게 만들었습니다.
또한, enum을 사용하여 확장성이 용이하도록 기물을 관리했습니다.
마지막으로 기물들에 대한 점수 계산, 남아있는 기물들을 점수별 오름차순/내림차순 정렬하여 반환 받을 수 있는 메서드를 구현했습니다.

## 고민 사항
코드가 길어짐에 따라 코드를 깔끔하게 정렬하고 배치시키고 싶은데, 이와 관련된 팁에 대해 고민중입니다.

## 기타
