### PR TITLE
[hseong3243] step-6 기물 이동 구현

### DIFF
--- a/src/main/java/com/seong/Main.java
+++ b/src/main/java/com/seong/Main.java
@@ -7,19 +7,22 @@ public class Main {
 
     public static final String START = "start";
     public static final String END = "end";
+    public static final String MOVE = "move";
 
     public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
+        Board board = new Board();
         while (sc.hasNext()) {
-            String command = sc.next();
-            Board board;
+            String command = sc.nextLine();
             if (command.equals(START)) {
-                board = new Board();
                 board.initialize();
             } else if (command.equals(END)) {
                 break;
-            } else {
-                continue;
+            } else if (command.startsWith(MOVE)) {
+                String[] commands = command.split(" ");
+                String sourcePosition = commands[1];
+                String targetPosition = commands[2];
+                board.move(sourcePosition, targetPosition);
             }
             System.out.println(board.showBoard());
         }

--- a/src/main/java/com/seong/Main.java
+++ b/src/main/java/com/seong/Main.java
@@ -1,6 +1,7 @@
 package com.seong;
 
 import com.seong.chess.Board;
+import com.seong.chess.ChessGame;
 import java.util.Scanner;
 
 public class Main {
@@ -12,17 +13,18 @@ public class Main {
     public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
         Board board = new Board();
+        ChessGame chessGame = new ChessGame(board);
         while (sc.hasNext()) {
             String command = sc.nextLine();
             if (command.equals(START)) {
-                board.initialize();
+                chessGame.initialize();
             } else if (command.equals(END)) {
                 break;
             } else if (command.startsWith(MOVE)) {
                 String[] commands = command.split(" ");
                 String sourcePosition = commands[1];
                 String targetPosition = commands[2];
-                board.move(sourcePosition, targetPosition);
+                chessGame.move(sourcePosition, targetPosition);
             }
             System.out.println(board.showBoard());
         }

--- a/src/main/java/com/seong/chess/Board.java
+++ b/src/main/java/com/seong/chess/Board.java
@@ -75,9 +75,6 @@ public class Board {
                 pawnCount++;
             }
         }
-        if (pawnCount > 1) {
-            pawnCount *= 0.5;
-        }
         return pawnCount;
     }
 

--- a/src/main/java/com/seong/chess/Board.java
+++ b/src/main/java/com/seong/chess/Board.java
@@ -12,32 +12,6 @@ import java.util.List;
 
 public class Board {
 
-    public record Position(int col, int row) {
-
-        public Position {
-            validateRow(row);
-            validateCol(col);
-        }
-
-        public static Position convert(String rawPosition) {
-            int col = rawPosition.charAt(0) - 'a';
-            int row = 8 - Character.getNumericValue(rawPosition.charAt(1));
-            return new Position(col, row);
-        }
-
-        private void validateRow(int row) {
-            if (row < 0 || row >= 8) {
-                throw new IllegalArgumentException("체스 보드 행은 1이상, 8 이하입니다.");
-            }
-        }
-
-        private void validateCol(int col) {
-            if (col < 0 || col >= 8) {
-                throw new IllegalArgumentException("체스 보드 열은 a이상, h 이하입니다.");
-            }
-        }
-    }
-
     private static final int EMPTY_ROW_BEGIN = 2;
     private static final int EMPTY_ROW_END = 6;
     static final int BOARD_LENGTH = 8;
@@ -86,7 +60,7 @@ public class Board {
 
     public void move(String rawPosition, Piece piece) {
         Position position = Position.convert(rawPosition);
-        ranks.get(position.row).move(position.col, piece);
+        ranks.get(position.row()).move(position.col(), piece);
     }
 
     public void move(String sourcePosition, String targetPosition) {
@@ -97,7 +71,7 @@ public class Board {
 
     public Piece findPiece(String rawPosition) {
         Position position = Position.convert(rawPosition);
-        return ranks.get(position.row).get(position.col);
+        return ranks.get(position.row()).get(position.col());
     }
 
     public double calculatePoint(Color color) {

--- a/src/main/java/com/seong/chess/Board.java
+++ b/src/main/java/com/seong/chess/Board.java
@@ -2,6 +2,7 @@ package com.seong.chess;
 
 import static com.seong.chess.utils.StringUtils.appendNewLine;
 
+import com.seong.chess.pieces.Blank;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
 import com.seong.chess.pieces.Piece.Type;
@@ -11,14 +12,14 @@ import java.util.List;
 
 public class Board {
 
-    private record Position(int col, int row) {
+    public record Position(int col, int row) {
 
-        private Position {
+        public Position {
             validateRow(row);
             validateCol(col);
         }
 
-        private static Position convert(String rawPosition) {
+        public static Position convert(String rawPosition) {
             int col = rawPosition.charAt(0) - 'a';
             int row = 8 - Character.getNumericValue(rawPosition.charAt(1));
             return new Position(col, row);
@@ -86,6 +87,12 @@ public class Board {
     public void move(String rawPosition, Piece piece) {
         Position position = Position.convert(rawPosition);
         ranks.get(position.row).move(position.col, piece);
+    }
+
+    public void move(String sourcePosition, String targetPosition) {
+        Piece piece = findPiece(sourcePosition);
+        move(sourcePosition, Blank.create());
+        move(targetPosition, piece);
     }
 
     public Piece findPiece(String rawPosition) {

--- a/src/main/java/com/seong/chess/Board.java
+++ b/src/main/java/com/seong/chess/Board.java
@@ -2,7 +2,6 @@ package com.seong.chess;
 
 import static com.seong.chess.utils.StringUtils.appendNewLine;
 
-import com.seong.chess.pieces.Blank;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
 import com.seong.chess.pieces.Piece.Type;
@@ -63,31 +62,12 @@ public class Board {
         ranks.get(position.row()).move(position.col(), piece);
     }
 
-    public void move(String sourcePosition, String targetPosition) {
-        Piece piece = findPiece(sourcePosition);
-        move(sourcePosition, Blank.create());
-        move(targetPosition, piece);
-    }
-
     public Piece findPiece(String rawPosition) {
         Position position = Position.convert(rawPosition);
         return ranks.get(position.row()).get(position.col());
     }
 
-    public double calculatePoint(Color color) {
-        Double result = ranks.stream()
-                .flatMap(rank -> rank.getSameColorPieces(color).stream())
-                .filter(piece -> !piece.isEqual(Type.PAWN, color))
-                .reduce(0D, (point, piece) -> point + piece.getDefaultPoint(), Double::sum);
-
-        for (int i = 0; i < BOARD_LENGTH; i++) {
-            double pawnCount = getColumnPawnCount(color, i);
-            result += pawnCount * Type.PAWN.getDefaultPoint();
-        }
-        return result;
-    }
-
-    private double getColumnPawnCount(Color color, int row) {
+    public double getColumnPawnCount(Color color, int row) {
         double pawnCount = 0;
         for (int col = 0; col < BOARD_LENGTH; col++) {
             Piece piece = ranks.get(col).get(row);

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -20,9 +20,9 @@ public class ChessGame {
         board.move(targetPosition, piece);
     }
 
-    public void move(String sourcePosition, Direction direction) {
+    public void move(String sourcePosition, Direction direction, int moveCount) {
         Piece piece = board.findPiece(sourcePosition);
-        Position targetPosition = piece.nextPosition(sourcePosition, direction, 7);
+        Position targetPosition = piece.nextPosition(sourcePosition, direction, moveCount);
         board.move(targetPosition.convert(), piece);
     }
 

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -22,7 +22,7 @@ public class ChessGame {
 
     public void move(String sourcePosition, Direction direction) {
         Piece piece = board.findPiece(sourcePosition);
-        Position targetPosition = piece.nextPosition(sourcePosition, direction);
+        Position targetPosition = piece.nextPosition(sourcePosition, direction, 7);
         board.move(targetPosition.convert(), piece);
     }
 

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -3,6 +3,7 @@ package com.seong.chess;
 import com.seong.chess.pieces.Blank;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
+import com.seong.chess.pieces.Piece.Direction;
 import com.seong.chess.pieces.Piece.Type;
 
 public class ChessGame {
@@ -17,6 +18,12 @@ public class ChessGame {
         Piece piece = board.findPiece(sourcePosition);
         board.move(sourcePosition, Blank.create());
         board.move(targetPosition, piece);
+    }
+
+    public void move(String sourcePosition, Direction direction) {
+        Piece piece = board.findPiece(sourcePosition);
+        Position targetPosition = piece.nextPosition(sourcePosition, direction);
+        board.move(targetPosition.convert(), piece);
     }
 
     public void initialize() {

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -30,6 +30,9 @@ public class ChessGame {
 
         for (int i = 0; i < Board.BOARD_LENGTH; i++) {
             double pawnCount = board.getColumnPawnCount(color, i);
+            if (pawnCount > 1) {
+                pawnCount *= 0.5;
+            }
             result += pawnCount * Type.PAWN.getDefaultPoint();
         }
         return result;

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -1,0 +1,37 @@
+package com.seong.chess;
+
+import com.seong.chess.pieces.Blank;
+import com.seong.chess.pieces.Piece;
+import com.seong.chess.pieces.Piece.Color;
+import com.seong.chess.pieces.Piece.Type;
+
+public class ChessGame {
+
+    private final Board board;
+
+    public ChessGame(Board board) {
+        this.board = board;
+    }
+
+    public void move(String sourcePosition, String targetPosition) {
+        Piece piece = board.findPiece(sourcePosition);
+        board.move(sourcePosition, Blank.create());
+        board.move(targetPosition, piece);
+    }
+
+    public void initialize() {
+        board.initialize();
+    }
+
+    public double calculatePoint(Color color) {
+        Double result = board.getPiecesOrderByHighestScore(color).stream()
+                .filter(piece -> !piece.isEqual(Type.PAWN, color))
+                .reduce(0D, (point, piece) -> point + piece.getDefaultPoint(), Double::sum);
+
+        for (int i = 0; i < Board.BOARD_LENGTH; i++) {
+            double pawnCount = board.getColumnPawnCount(color, i);
+            result += pawnCount * Type.PAWN.getDefaultPoint();
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/seong/chess/ChessGame.java
+++ b/src/main/java/com/seong/chess/ChessGame.java
@@ -1,9 +1,9 @@
 package com.seong.chess;
 
 import com.seong.chess.pieces.Blank;
+import com.seong.chess.pieces.Direction;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
-import com.seong.chess.pieces.Piece.Direction;
 import com.seong.chess.pieces.Piece.Type;
 
 public class ChessGame {

--- a/src/main/java/com/seong/chess/Position.java
+++ b/src/main/java/com/seong/chess/Position.java
@@ -1,0 +1,27 @@
+package com.seong.chess;
+
+public record Position(int col, int row) {
+
+    public Position {
+        validateRow(row);
+        validateCol(col);
+    }
+
+    public static Position convert(String rawPosition) {
+        int col = rawPosition.charAt(0) - 'a';
+        int row = 8 - Character.getNumericValue(rawPosition.charAt(1));
+        return new Position(col, row);
+    }
+
+    private void validateRow(int row) {
+        if (row < 0 || row >= 8) {
+            throw new IllegalArgumentException("체스 보드 행은 1이상, 8 이하입니다.");
+        }
+    }
+
+    private void validateCol(int col) {
+        if (col < 0 || col >= 8) {
+            throw new IllegalArgumentException("체스 보드 열은 a이상, h 이하입니다.");
+        }
+    }
+}

--- a/src/main/java/com/seong/chess/Position.java
+++ b/src/main/java/com/seong/chess/Position.java
@@ -24,4 +24,10 @@ public record Position(int col, int row) {
             throw new IllegalArgumentException("체스 보드 열은 a이상, h 이하입니다.");
         }
     }
+
+    public String convert() {
+        char rawCol = (char) (col + 'a');
+        char rawRow = (char) (7 - row + '1');
+        return String.valueOf(rawCol) + rawRow;
+    }
 }

--- a/src/main/java/com/seong/chess/Position.java
+++ b/src/main/java/com/seong/chess/Position.java
@@ -30,4 +30,8 @@ public record Position(int col, int row) {
         char rawRow = (char) (7 - row + '1');
         return String.valueOf(rawCol) + rawRow;
     }
+
+    public boolean isPawnRow() {
+        return row == 1 || row == 6;
+    }
 }

--- a/src/main/java/com/seong/chess/pieces/Bishop.java
+++ b/src/main/java/com/seong/chess/pieces/Bishop.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Bishop extends Piece {
 
     private static final char REPRESENTATION = 'b';
@@ -20,5 +22,10 @@ public class Bishop extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Bishop.java
+++ b/src/main/java/com/seong/chess/pieces/Bishop.java
@@ -26,6 +26,12 @@ public class Bishop extends Piece {
 
     @Override
     public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        return null;
+        direction.checkBishop();
+        Position position = Position.convert(sourcePosition);
+        if (moveCount == 0) {
+            return position;
+        }
+        Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
+        return nextPosition(nextPosition.convert(), direction, moveCount - 1);
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Bishop.java
+++ b/src/main/java/com/seong/chess/pieces/Bishop.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class Bishop extends Piece {
 
     private static final char REPRESENTATION = 'b';
@@ -25,13 +23,10 @@ public class Bishop extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        direction.checkBishop();
-        Position position = Position.convert(sourcePosition);
-        if (moveCount == 0) {
-            return position;
+    public void checkPieceCanMove(Direction direction) {
+        if (direction.isDiagonal()) {
+            return;
         }
-        Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
-        return nextPosition(nextPosition.convert(), direction, moveCount - 1);
+        throw new IllegalArgumentException("비숍은 정방향으로 이동할 수 없습니다.");
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Blank.java
+++ b/src/main/java/com/seong/chess/pieces/Blank.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Blank extends Piece {
 
     private static final char REPRESENTATION = '.';
@@ -16,5 +18,10 @@ public class Blank extends Piece {
     @Override
     public boolean isNotBlank() {
         return true;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Blank.java
+++ b/src/main/java/com/seong/chess/pieces/Blank.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class Blank extends Piece {
 
     private static final char REPRESENTATION = '.';
@@ -21,7 +19,7 @@ public class Blank extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        return null;
+    public void checkPieceCanMove(Direction direction) {
+
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Direction.java
+++ b/src/main/java/com/seong/chess/pieces/Direction.java
@@ -1,0 +1,20 @@
+package com.seong.chess.pieces;
+
+public enum Direction {
+    NORTH(-1, 0),
+    SOUTH(1, 0),
+    EAST(0, 1),
+    WEST(0, -1),
+    NORTHEAST(-1, 1),
+    SOUTHEAST(1, 1),
+    SOUTHWEST(1, -1),
+    NORTHWEST(-1, -1);
+
+    final int row;
+    final int col;
+
+    Direction(int row, int col) {
+        this.row = row;
+        this.col = col;
+    }
+}

--- a/src/main/java/com/seong/chess/pieces/Direction.java
+++ b/src/main/java/com/seong/chess/pieces/Direction.java
@@ -17,4 +17,10 @@ public enum Direction {
         this.row = row;
         this.col = col;
     }
+
+    public void checkBishop() {
+        if (this == NORTH || this == SOUTH || this == EAST || this == WEST) {
+            throw new IllegalArgumentException("비숍은 정방향으로 이동할 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/seong/chess/pieces/Direction.java
+++ b/src/main/java/com/seong/chess/pieces/Direction.java
@@ -8,7 +8,16 @@ public enum Direction {
     NORTHEAST(-1, 1),
     SOUTHEAST(1, 1),
     SOUTHWEST(1, -1),
-    NORTHWEST(-1, -1);
+    NORTHWEST(-1, -1),
+
+    NNE(-2, 1),
+    EEN(-1, 2),
+    EES(1, 2),
+    SSE(2, 1),
+    SSW(2, -1),
+    WWS(1, -2),
+    WWN(-1, -2),
+    NNW(-2, -1);
 
     final int row;
     final int col;
@@ -21,6 +30,13 @@ public enum Direction {
     public void checkBishop() {
         if (this == NORTH || this == SOUTH || this == EAST || this == WEST) {
             throw new IllegalArgumentException("비숍은 정방향으로 이동할 수 없습니다.");
+        }
+    }
+
+    public void checkKnight() {
+        if (this == NORTH || this == SOUTH || this == EAST || this == WEST ||
+                this == NORTHEAST || this == SOUTHEAST || this == NORTHWEST || this == SOUTHWEST) {
+            throw new IllegalArgumentException("나이트는 정방향, 대각선으로 이동할 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Direction.java
+++ b/src/main/java/com/seong/chess/pieces/Direction.java
@@ -27,16 +27,11 @@ public enum Direction {
         this.col = col;
     }
 
-    public void checkBishop() {
-        if (this == NORTH || this == SOUTH || this == EAST || this == WEST) {
-            throw new IllegalArgumentException("비숍은 정방향으로 이동할 수 없습니다.");
-        }
+    public boolean isRight() {
+        return this == NORTH || this == SOUTH || this == EAST || this == WEST;
     }
 
-    public void checkKnight() {
-        if (this == NORTH || this == SOUTH || this == EAST || this == WEST ||
-                this == NORTHEAST || this == SOUTHEAST || this == NORTHWEST || this == SOUTHWEST) {
-            throw new IllegalArgumentException("나이트는 정방향, 대각선으로 이동할 수 없습니다.");
-        }
+    public boolean isDiagonal() {
+        return this == NORTHEAST || this == SOUTHEAST || this == NORTHWEST || this == SOUTHWEST;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/King.java
+++ b/src/main/java/com/seong/chess/pieces/King.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class King extends Piece {
 
     private static final char REPRESENTATION = 'k';
@@ -20,5 +22,11 @@ public class King extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        Position position = Position.convert(sourcePosition);
+        return new Position(position.col() + direction.col, position.row() + direction.row);
     }
 }

--- a/src/main/java/com/seong/chess/pieces/King.java
+++ b/src/main/java/com/seong/chess/pieces/King.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class King extends Piece {
 
     private static final char REPRESENTATION = 'k';
@@ -25,8 +23,10 @@ public class King extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        Position position = Position.convert(sourcePosition);
-        return new Position(position.col() + direction.col, position.row() + direction.row);
+    public void checkPieceCanMove(Direction direction) {
+        if (direction.isRight() || direction.isDiagonal()) {
+            return;
+        }
+        throw new IllegalArgumentException("킹은 정방향, 대각선으로만 움직일 수 있습니다.");
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Knight.java
+++ b/src/main/java/com/seong/chess/pieces/Knight.java
@@ -26,6 +26,8 @@ public class Knight extends Piece {
 
     @Override
     public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        return null;
+        direction.checkKnight();
+        Position position = Position.convert(sourcePosition);
+        return new Position(position.col() + direction.col, position.row() + direction.row);
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Knight.java
+++ b/src/main/java/com/seong/chess/pieces/Knight.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Knight extends Piece {
 
     private static final char REPRESENTATION = 'n';
@@ -20,5 +22,10 @@ public class Knight extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Knight.java
+++ b/src/main/java/com/seong/chess/pieces/Knight.java
@@ -26,8 +26,15 @@ public class Knight extends Piece {
 
     @Override
     public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        direction.checkKnight();
+        checkPieceCanMove(direction);
         Position position = Position.convert(sourcePosition);
         return new Position(position.col() + direction.col, position.row() + direction.row);
+    }
+
+    @Override
+    public void checkPieceCanMove(Direction direction) {
+        if (direction.isDiagonal() || direction.isRight()) {
+            throw new IllegalArgumentException("킹은 정방향, 대각선으로 움직일 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Pawn.java
+++ b/src/main/java/com/seong/chess/pieces/Pawn.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Pawn extends Piece {
 
     private static final char REPRESENTATION = 'p';
@@ -23,7 +25,34 @@ public class Pawn extends Piece {
     }
 
     @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        checkPieceCanMove(direction);
+        Position position = Position.convert(sourcePosition);
+        checkMoveCount(position, moveCount);
+        return new Position(position.col() + direction.col * moveCount, position.row() + direction.row * moveCount);
+    }
+
+    @Override
     public void checkPieceCanMove(Direction direction) {
+        if (color == Color.WHITE && direction == Direction.NORTH) {
+            return;
+        }
+        if (color == Color.BLACK && direction == Direction.SOUTH) {
+            return;
+        }
+        throw new IllegalArgumentException("폰은 전진만 할 수 있습니다.");
+    }
+
+    private void checkMoveCount(Position position, int moveCount) {
+        if (moveCount > 2) {
+            throw new IllegalArgumentException("폰은 2칸 이하로만 움직일 수 있습니다.");
+        }
+        if (moveCount == 2) {
+            if (position.isPawnRow()) {
+                return;
+            }
+            throw new IllegalArgumentException("초기상태의 폰만 2칸 이상으로 움직일 수 있습니다.");
+        }
 
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Pawn.java
+++ b/src/main/java/com/seong/chess/pieces/Pawn.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class Pawn extends Piece {
 
     private static final char REPRESENTATION = 'p';
@@ -25,7 +23,7 @@ public class Pawn extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        return null;
+    public void checkPieceCanMove(Direction direction) {
+
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Pawn.java
+++ b/src/main/java/com/seong/chess/pieces/Pawn.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Pawn extends Piece {
 
     private static final char REPRESENTATION = 'p';
@@ -20,5 +22,10 @@ public class Pawn extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -133,7 +133,17 @@ public abstract class Piece {
         return this.color == color;
     }
 
-    public abstract Position nextPosition(String sourcePosition, Direction direction, int moveCount);
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        checkPieceCanMove(direction);
+        Position position = Position.convert(sourcePosition);
+        if (moveCount == 0) {
+            return position;
+        }
+        Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
+        return nextPosition(nextPosition.convert(), direction, moveCount - 1);
+    }
+
+    public abstract void checkPieceCanMove(Direction direction);
 
     public double getDefaultPoint() {
         return defaultPoint;

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -1,5 +1,6 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Board.Position;
 import java.util.Objects;
 
 public abstract class Piece {
@@ -50,8 +51,16 @@ public abstract class Piece {
         this.defaultPoint = defaultPoint;
     }
 
+    public static Piece createBlank(Position position) {
+        return Blank.create();
+    }
+
     public static Piece createBlank() {
         return Blank.create();
+    }
+
+    public static Piece createWhitePawn(Position position) {
+        return Pawn.createWhite();
     }
 
     public static Piece createWhitePawn() {

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -39,6 +39,25 @@ public abstract class Piece {
         }
     }
 
+    public enum Direction {
+        NORTH(-1, 0),
+        SOUTH(1, 0),
+        EAST(0, 1),
+        WEST(0, -1),
+        NORTHEAST(-1, 1),
+        SOUTHEAST(1, 1),
+        SOUTHWEST(1, -1),
+        NORTHWEST(-1, -1);
+
+        private final int row;
+        private final int col;
+
+        Direction(int row, int col) {
+            this.row = row;
+            this.col = col;
+        }
+    }
+
     private final Type type;  // 추후 제거
     protected final Color color;
     protected final char representation;
@@ -131,6 +150,11 @@ public abstract class Piece {
 
     public boolean isEqual(Color color) {
         return this.color == color;
+    }
+
+    public Position nextPosition(String sourcePosition, Direction direction) {
+        Position position = Position.convert(sourcePosition);
+        return new Position(position.col() + direction.col, position.row() + direction.row);
     }
 
     public double getDefaultPoint() {

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -1,6 +1,6 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Board.Position;
+import com.seong.chess.Position;
 import java.util.Objects;
 
 public abstract class Piece {

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -39,25 +39,6 @@ public abstract class Piece {
         }
     }
 
-    public enum Direction {
-        NORTH(-1, 0),
-        SOUTH(1, 0),
-        EAST(0, 1),
-        WEST(0, -1),
-        NORTHEAST(-1, 1),
-        SOUTHEAST(1, 1),
-        SOUTHWEST(1, -1),
-        NORTHWEST(-1, -1);
-
-        private final int row;
-        private final int col;
-
-        Direction(int row, int col) {
-            this.row = row;
-            this.col = col;
-        }
-    }
-
     private final Type type;  // 추후 제거
     protected final Color color;
     protected final char representation;
@@ -152,25 +133,7 @@ public abstract class Piece {
         return this.color == color;
     }
 
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        Position position = Position.convert(sourcePosition);
-        if (moveCount == 0) {
-            return Position.convert(sourcePosition);
-        }
-
-        try {
-            Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
-            if (this instanceof King) {
-                return nextPosition(nextPosition.convert(), direction, 0);
-            } else if (this instanceof Queen) {
-                return nextPosition(nextPosition.convert(), direction, moveCount - 1);
-            } else {
-                throw new IllegalStateException("체스 기물이 아닙니다.");
-            }
-        } catch (IllegalArgumentException e) {
-            return nextPosition(sourcePosition, direction, 0);
-        }
-    }
+    public abstract Position nextPosition(String sourcePosition, Direction direction, int moveCount);
 
     public double getDefaultPoint() {
         return defaultPoint;

--- a/src/main/java/com/seong/chess/pieces/Piece.java
+++ b/src/main/java/com/seong/chess/pieces/Piece.java
@@ -152,9 +152,24 @@ public abstract class Piece {
         return this.color == color;
     }
 
-    public Position nextPosition(String sourcePosition, Direction direction) {
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
         Position position = Position.convert(sourcePosition);
-        return new Position(position.col() + direction.col, position.row() + direction.row);
+        if (moveCount == 0) {
+            return Position.convert(sourcePosition);
+        }
+
+        try {
+            Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
+            if (this instanceof King) {
+                return nextPosition(nextPosition.convert(), direction, 0);
+            } else if (this instanceof Queen) {
+                return nextPosition(nextPosition.convert(), direction, moveCount - 1);
+            } else {
+                throw new IllegalStateException("체스 기물이 아닙니다.");
+            }
+        } catch (IllegalArgumentException e) {
+            return nextPosition(sourcePosition, direction, 0);
+        }
     }
 
     public double getDefaultPoint() {

--- a/src/main/java/com/seong/chess/pieces/Queen.java
+++ b/src/main/java/com/seong/chess/pieces/Queen.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Queen extends Piece {
 
     private static final char REPRESENTATION = 'q';
@@ -20,5 +22,15 @@ public class Queen extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        Position position = Position.convert(sourcePosition);
+        if (moveCount == 0) {
+            return position;
+        }
+        Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
+        return nextPosition(nextPosition.convert(), direction, moveCount - 1);
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Queen.java
+++ b/src/main/java/com/seong/chess/pieces/Queen.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class Queen extends Piece {
 
     private static final char REPRESENTATION = 'q';
@@ -25,12 +23,10 @@ public class Queen extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        Position position = Position.convert(sourcePosition);
-        if (moveCount == 0) {
-            return position;
+    public void checkPieceCanMove(Direction direction) {
+        if (direction.isDiagonal() || direction.isRight()) {
+            return;
         }
-        Position nextPosition = new Position(position.col() + direction.col, position.row() + direction.row);
-        return nextPosition(nextPosition.convert(), direction, moveCount - 1);
+        throw new IllegalArgumentException("퀸은 정방향, 대각선으로만 움직일 수 있습니다.");
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Rook.java
+++ b/src/main/java/com/seong/chess/pieces/Rook.java
@@ -1,5 +1,7 @@
 package com.seong.chess.pieces;
 
+import com.seong.chess.Position;
+
 public class Rook extends Piece {
 
     private static final char REPRESENTATION = 'r';
@@ -20,5 +22,10 @@ public class Rook extends Piece {
     @Override
     public boolean isNotBlank() {
         return false;
+    }
+
+    @Override
+    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
+        return null;
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Rook.java
+++ b/src/main/java/com/seong/chess/pieces/Rook.java
@@ -1,7 +1,5 @@
 package com.seong.chess.pieces;
 
-import com.seong.chess.Position;
-
 public class Rook extends Piece {
 
     private static final char REPRESENTATION = 'r';
@@ -25,7 +23,7 @@ public class Rook extends Piece {
     }
 
     @Override
-    public Position nextPosition(String sourcePosition, Direction direction, int moveCount) {
-        return null;
+    public void checkPieceCanMove(Direction direction) {
+
     }
 }

--- a/src/main/java/com/seong/chess/pieces/Rook.java
+++ b/src/main/java/com/seong/chess/pieces/Rook.java
@@ -9,11 +9,11 @@ public class Rook extends Piece {
         super(Type.ROOK, color, REPRESENTATION, DEFAULT_POINT);
     }
 
-    public static Piece createWhite() {
+    public static Rook createWhite() {
         return new Rook(Color.WHITE);
     }
 
-    public static Piece createBlack() {
+    public static Rook createBlack() {
         return new Rook(Color.BLACK);
     }
 
@@ -24,6 +24,9 @@ public class Rook extends Piece {
 
     @Override
     public void checkPieceCanMove(Direction direction) {
-
+        if (direction.isRight()) {
+            return;
+        }
+        throw new IllegalArgumentException("룩은 정방향으로만 움직일 수 있습니다.");
     }
 }

--- a/src/test/java/com/seong/chess/BoardTest.java
+++ b/src/test/java/com/seong/chess/BoardTest.java
@@ -76,7 +76,7 @@ public class BoardTest {
 
     @Test
     @DisplayName("체스 보드에 임의의 기물을 추가할 수 있다.")
-    public void move() throws Exception {
+    public void moveRandomPiece() throws Exception {
         board.initializeEmpty();
 
         String position = "b5";
@@ -150,5 +150,17 @@ public class BoardTest {
                         Piece.createBlackRook(), Piece.createBlackRook(),
                         Piece.createBlackQueen()
                 );
+    }
+
+    @Test
+    @DisplayName("체스 보드의 기물은 현재 위치에서 다른 위치로 이동할 수 있다.")
+    public void move() throws Exception {
+        board.initialize();
+
+        String sourcePosition = "b2";
+        String targetPosition = "b3";
+        board.move(sourcePosition, targetPosition);
+        assertEquals(Piece.createBlank(Board.Position.convert(sourcePosition)), board.findPiece(sourcePosition));
+        assertEquals(Piece.createWhitePawn(Board.Position.convert(targetPosition)), board.findPiece(targetPosition));
     }
 }

--- a/src/test/java/com/seong/chess/BoardTest.java
+++ b/src/test/java/com/seong/chess/BoardTest.java
@@ -160,7 +160,7 @@ public class BoardTest {
         String sourcePosition = "b2";
         String targetPosition = "b3";
         board.move(sourcePosition, targetPosition);
-        assertEquals(Piece.createBlank(Board.Position.convert(sourcePosition)), board.findPiece(sourcePosition));
-        assertEquals(Piece.createWhitePawn(Board.Position.convert(targetPosition)), board.findPiece(targetPosition));
+        assertEquals(Piece.createBlank(Position.convert(sourcePosition)), board.findPiece(sourcePosition));
+        assertEquals(Piece.createWhitePawn(Position.convert(targetPosition)), board.findPiece(targetPosition));
     }
 }

--- a/src/test/java/com/seong/chess/BoardTest.java
+++ b/src/test/java/com/seong/chess/BoardTest.java
@@ -88,31 +88,6 @@ public class BoardTest {
     }
 
     @Test
-    @DisplayName("체스판 위의 기물에 따라 점수를 계산할 수 있다.")
-    public void calculatePoint() throws Exception {
-        board.initializeEmpty();
-
-        addPiece("b6", Piece.createBlackPawn());
-        addPiece("e6", Piece.createBlackQueen());
-        addPiece("b8", Piece.createBlackKing());
-        addPiece("c8", Piece.createBlackRook());
-
-        addPiece("f2", Piece.createWhitePawn());
-        addPiece("g2", Piece.createWhitePawn());
-        addPiece("e1", Piece.createWhiteRook());
-        addPiece("f1", Piece.createWhiteKing());
-
-        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
-        assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
-
-        System.out.println(board.showBoard());
-    }
-
-    private void addPiece(String position, Piece piece) {
-        board.move(position, piece);
-    }
-
-    @Test
     @DisplayName("체스 보드의 기물을 점수가 높은 순으로 정렬할 수 있다.")
     public void piecesOrderByScoreDesc() {
         board.initialize();
@@ -150,17 +125,5 @@ public class BoardTest {
                         Piece.createBlackRook(), Piece.createBlackRook(),
                         Piece.createBlackQueen()
                 );
-    }
-
-    @Test
-    @DisplayName("체스 보드의 기물은 현재 위치에서 다른 위치로 이동할 수 있다.")
-    public void move() throws Exception {
-        board.initialize();
-
-        String sourcePosition = "b2";
-        String targetPosition = "b3";
-        board.move(sourcePosition, targetPosition);
-        assertEquals(Piece.createBlank(Position.convert(sourcePosition)), board.findPiece(sourcePosition));
-        assertEquals(Piece.createWhitePawn(Position.convert(targetPosition)), board.findPiece(targetPosition));
     }
 }

--- a/src/test/java/com/seong/chess/ChessGameTest.java
+++ b/src/test/java/com/seong/chess/ChessGameTest.java
@@ -69,7 +69,7 @@ class ChessGameTest {
         onlyKing.move("a2", King.createBlack());
 
         //when
-        kingChessGame.move("a2", Direction.NORTH);
+        kingChessGame.move("a2", Direction.NORTH, 1);
 
         //then
         assertThat(onlyKing.findPiece("a3")).isEqualTo(King.createBlack());

--- a/src/test/java/com/seong/chess/ChessGameTest.java
+++ b/src/test/java/com/seong/chess/ChessGameTest.java
@@ -1,9 +1,12 @@
 package com.seong.chess;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.seong.chess.pieces.King;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
+import com.seong.chess.pieces.Piece.Direction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,5 +57,21 @@ class ChessGameTest {
 
     private void addPiece(String position, Piece piece) {
         board.move(position, piece);
+    }
+
+    @Test
+    @DisplayName("체스 게임의 기물을 움직일 수 있다.")
+    public void moveChessPieces() {
+        //given
+        Board onlyKing = new Board();
+        ChessGame kingChessGame = new ChessGame(onlyKing);
+        onlyKing.initializeEmpty();
+        onlyKing.move("a2", King.createBlack());
+
+        //when
+        kingChessGame.move("a2", Direction.NORTH);
+
+        //then
+        assertThat(onlyKing.findPiece("a3")).isEqualTo(King.createBlack());
     }
 }

--- a/src/test/java/com/seong/chess/ChessGameTest.java
+++ b/src/test/java/com/seong/chess/ChessGameTest.java
@@ -3,10 +3,10 @@ package com.seong.chess;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.seong.chess.pieces.Direction;
 import com.seong.chess.pieces.King;
 import com.seong.chess.pieces.Piece;
 import com.seong.chess.pieces.Piece.Color;
-import com.seong.chess.pieces.Piece.Direction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/seong/chess/ChessGameTest.java
+++ b/src/test/java/com/seong/chess/ChessGameTest.java
@@ -1,0 +1,58 @@
+package com.seong.chess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.seong.chess.pieces.Piece;
+import com.seong.chess.pieces.Piece.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ChessGameTest {
+
+    private Board board;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    void setUp() {
+        board = new Board();
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("체스 보드의 기물은 현재 위치에서 다른 위치로 이동할 수 있다.")
+    public void move() throws Exception {
+        chessGame.initialize();
+
+        String sourcePosition = "b2";
+        String targetPosition = "b3";
+        chessGame.move(sourcePosition, targetPosition);
+        assertEquals(Piece.createBlank(Position.convert(sourcePosition)), board.findPiece(sourcePosition));
+        assertEquals(Piece.createWhitePawn(Position.convert(targetPosition)), board.findPiece(targetPosition));
+    }
+
+    @Test
+    @DisplayName("체스판 위의 기물에 따라 점수를 계산할 수 있다.")
+    public void calculatePoint() throws Exception {
+        board.initializeEmpty();
+
+        addPiece("b6", Piece.createBlackPawn());
+        addPiece("e6", Piece.createBlackQueen());
+        addPiece("b8", Piece.createBlackKing());
+        addPiece("c8", Piece.createBlackRook());
+
+        addPiece("f2", Piece.createWhitePawn());
+        addPiece("g2", Piece.createWhitePawn());
+        addPiece("e1", Piece.createWhiteRook());
+        addPiece("f1", Piece.createWhiteKing());
+
+        assertEquals(15.0, chessGame.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.0, chessGame.calculatePoint(Color.WHITE), 0.01);
+
+        System.out.println(board.showBoard());
+    }
+
+    private void addPiece(String position, Piece piece) {
+        board.move(position, piece);
+    }
+}

--- a/src/test/java/com/seong/chess/PositionTest.java
+++ b/src/test/java/com/seong/chess/PositionTest.java
@@ -1,0 +1,26 @@
+package com.seong.chess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PositionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "0,0,a8", "7,7,h1", "2,2,c6"
+    })
+    @DisplayName("행렬 포지션을 체스 포지션으로 컨버팅할 수 있다.")
+    public void convertToRawPosition(int row, int col, String expected) {
+        //given
+        Position position = new Position(col, row);
+
+        //when
+        String rawPosition = position.convert();
+
+        //then
+        assertThat(rawPosition).isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/BishopTest.java
+++ b/src/test/java/com/seong/chess/pieces/BishopTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.chess.Position;
+import java.util.Arrays;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,9 +37,9 @@ class BishopTest {
     }
 
     @ParameterizedTest
-    @MethodSource(value = "bishopCanNotMoveRightDirection")
+    @MethodSource(value = "bishopOnlyMoveDiagonalDirection")
     @DisplayName("비숍이 정방향으로 움직이려고 하면 예외가 발생한다.")
-    void bishopCanNotMoveRightDirection(Direction direction) {
+    void bishopOnlyMoveDiagonalDirection(Direction direction) {
         //given
         Bishop black = Bishop.createBlack();
         String sourcePosition = "d4";
@@ -50,36 +51,30 @@ class BishopTest {
         assertThat(exception).isInstanceOf(IllegalArgumentException.class);
     }
 
-    private static Stream<Arguments> bishopCanNotMoveRightDirection() {
-        return Stream.of(
-                Arguments.arguments(Direction.NORTH),
-                Arguments.arguments(Direction.SOUTH),
-                Arguments.arguments(Direction.WEST),
-                Arguments.arguments(Direction.EAST)
-        );
+    private static Stream<Arguments> bishopOnlyMoveDiagonalDirection() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> !direction.isDiagonal())
+                .map(Arguments::arguments);
     }
 
     @ParameterizedTest
     @MethodSource(value = "bishopMoveOverChessBoardThenException")
     @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
-    void bishopMoveOverChessBoardThenException(Direction direction, int moveCount) {
+    void bishopMoveOverChessBoardThenException(Direction direction) {
         //given
         Bishop black = Bishop.createBlack();
         String sourcePosition = "d4";
 
         //when
-        Exception exception = catchException(() -> black.nextPosition(sourcePosition, direction, moveCount));
+        Exception exception = catchException(() -> black.nextPosition(sourcePosition, direction, 100));
 
         //then
         assertThat(exception).isInstanceOf(IllegalArgumentException.class);
     }
 
     private static Stream<Arguments> bishopMoveOverChessBoardThenException() {
-        return Stream.of(
-                Arguments.arguments(Direction.NORTHEAST, 100),
-                Arguments.arguments(Direction.NORTHWEST, 100),
-                Arguments.arguments(Direction.SOUTHEAST, 100),
-                Arguments.arguments(Direction.SOUTHWEST, 100)
-        );
+        return Arrays.stream(Direction.values())
+                .filter(Direction::isDiagonal)
+                .map(Arguments::arguments);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/BishopTest.java
+++ b/src/test/java/com/seong/chess/pieces/BishopTest.java
@@ -1,0 +1,85 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.chess.Position;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BishopTest {
+
+    @ParameterizedTest
+    @MethodSource(value = "bishopMove")
+    @DisplayName("비숍은 대각선 방향으로 움직일 수 있다.")
+    void bishopMove(String sourcePosition, Direction direction, int moveCount, String expectedPosition) {
+        //given
+        Bishop black = Bishop.createBlack();
+
+        //when
+        Position nextPosition = black.nextPosition(sourcePosition, direction, moveCount);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
+    }
+
+    private static Stream<Arguments> bishopMove() {
+        return Stream.of(
+                Arguments.arguments("d5", Direction.NORTHEAST, 3, "g8"),
+                Arguments.arguments("d5", Direction.NORTHWEST, 3, "a8"),
+                Arguments.arguments("d5", Direction.SOUTHWEST, 3, "a2"),
+                Arguments.arguments("d5", Direction.SOUTHEAST, 4, "h1")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "bishopCanNotMoveRightDirection")
+    @DisplayName("비숍이 정방향으로 움직이려고 하면 예외가 발생한다.")
+    void bishopCanNotMoveRightDirection(Direction direction) {
+        //given
+        Bishop black = Bishop.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> black.nextPosition(sourcePosition, direction, 3));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> bishopCanNotMoveRightDirection() {
+        return Stream.of(
+                Arguments.arguments(Direction.NORTH),
+                Arguments.arguments(Direction.SOUTH),
+                Arguments.arguments(Direction.WEST),
+                Arguments.arguments(Direction.EAST)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "bishopMoveOverChessBoardThenException")
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
+    void bishopMoveOverChessBoardThenException(Direction direction, int moveCount) {
+        //given
+        Bishop black = Bishop.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> black.nextPosition(sourcePosition, direction, moveCount));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> bishopMoveOverChessBoardThenException() {
+        return Stream.of(
+                Arguments.arguments(Direction.NORTHEAST, 100),
+                Arguments.arguments(Direction.NORTHWEST, 100),
+                Arguments.arguments(Direction.SOUTHEAST, 100),
+                Arguments.arguments(Direction.SOUTHWEST, 100)
+        );
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/KingTest.java
+++ b/src/test/java/com/seong/chess/pieces/KingTest.java
@@ -1,0 +1,45 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.chess.pieces.Piece.Direction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class KingTest {
+
+    @Test
+    @DisplayName("킹은 모든 방향으로 1칸씩 움직일 수 있다.")
+    void kingMove() {
+        King king = King.createBlack();
+        String sourcePosition = "e2";
+
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTH).convert()).isEqualTo("e3");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTH).convert()).isEqualTo("e1");
+        assertThat(king.nextPosition(sourcePosition, Direction.EAST).convert()).isEqualTo("f2");
+        assertThat(king.nextPosition(sourcePosition, Direction.WEST).convert()).isEqualTo("d2");
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTHEAST).convert()).isEqualTo("f3");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHEAST).convert()).isEqualTo("f1");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHWEST).convert()).isEqualTo("d1");
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTHWEST).convert()).isEqualTo("d3");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "e1,SOUTH", "a1,WEST", "a8,NORTH", "h8,EAST"
+    })
+    @DisplayName("체스판 밖으로 움직이면 예외가 발생한다.")
+    void kingMoveWhenBoardOutThenException(String sourcePosition, String rawDirection) {
+        //given
+        King king = King.createBlack();
+
+        //when
+        Exception exception = catchException(() -> king.nextPosition(sourcePosition, Direction.valueOf(rawDirection)));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/KingTest.java
+++ b/src/test/java/com/seong/chess/pieces/KingTest.java
@@ -4,43 +4,82 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.chess.Position;
+import java.util.Arrays;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class KingTest {
 
     @ParameterizedTest
-    @CsvSource({
-            "e2,NORTH,e3", "e2,SOUTH,e1", "e2,EAST,f2", "e2,WEST,d2",
-            "e2,NORTHEAST,f3", "e2,SOUTHEAST,f1", "e2,SOUTHWEST,d1", "e2,NORTHWEST,d3"
-    })
+    @MethodSource("kingMove")
     @DisplayName("킹은 모든 방향으로 1칸씩 움직일 수 있다.")
-    void kingMove(String sourcePosition, String rawDirection, String expectedPosition) {
+    void kingMove(String sourcePosition, Direction direction, String expectedPosition) {
         //given
         King king = King.createBlack();
 
         //when
-        Position nextPosition = king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 7);
+        Position nextPosition = king.nextPosition(sourcePosition, direction, 1);
 
         //then
         assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
     }
 
+    private static Stream<Arguments> kingMove() {
+        return Stream.of(
+                Arguments.arguments("e2", Direction.NORTH, "e3"),
+                Arguments.arguments("e2", Direction.SOUTH, "e1"),
+                Arguments.arguments("e2", Direction.EAST, "f2"),
+                Arguments.arguments("e2", Direction.WEST, "d2"),
+                Arguments.arguments("e2", Direction.NORTHEAST, "f3"),
+                Arguments.arguments("e2", Direction.SOUTHEAST, "f1"),
+                Arguments.arguments("e2", Direction.SOUTHWEST, "d1"),
+                Arguments.arguments("e2", Direction.NORTHWEST, "d3")
+        );
+    }
+
     @ParameterizedTest
-    @CsvSource({
-            "e1,SOUTH", "a1,WEST", "a8,NORTH", "h8,EAST"
-    })
+    @MethodSource("kingMoveWhenBoardOutThenException")
     @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
-    void kingMoveWhenBoardOutThenException(String sourcePosition, String rawDirection) {
+    void kingMoveWhenBoardOutThenException(Direction direction) {
         //given
         King king = King.createBlack();
+        String sourcePosition = "d4";
 
         //when
         Exception exception = catchException(
-                () -> king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 1));
+                () -> king.nextPosition(sourcePosition, direction, 100));
 
         //then
         assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> kingMoveWhenBoardOutThenException() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> direction.isRight() || direction.isDiagonal())
+                .map(Arguments::arguments);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("킹이 정방향, 대각선 이외의 방향으로 움직이려 하면 예외가 발생한다.")
+    void kingOnlyMoveRightAndDiagonalDirectionButOthersException(Direction direction) {
+        //given
+        King king = King.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> king.nextPosition(sourcePosition, direction, 1));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> kingOnlyMoveRightAndDiagonalDirectionButOthersException() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> !(direction.isRight() || direction.isDiagonal()))
+                .map(Arguments::arguments);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/KingTest.java
+++ b/src/test/java/com/seong/chess/pieces/KingTest.java
@@ -1,45 +1,46 @@
 package com.seong.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.chess.Position;
-import com.seong.chess.pieces.Piece.Direction;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class KingTest {
 
-    @Test
+    @ParameterizedTest
+    @CsvSource({
+            "e2,NORTH,e3", "e2,SOUTH,e1", "e2,EAST,f2", "e2,WEST,d2",
+            "e2,NORTHEAST,f3", "e2,SOUTHEAST,f1", "e2,SOUTHWEST,d1", "e2,NORTHWEST,d3"
+    })
     @DisplayName("킹은 모든 방향으로 1칸씩 움직일 수 있다.")
-    void kingMove() {
+    void kingMove(String sourcePosition, String rawDirection, String expectedPosition) {
+        //given
         King king = King.createBlack();
-        String sourcePosition = "e2";
 
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTH, 7).convert()).isEqualTo("e3");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTH, 7).convert()).isEqualTo("e1");
-        assertThat(king.nextPosition(sourcePosition, Direction.EAST, 7).convert()).isEqualTo("f2");
-        assertThat(king.nextPosition(sourcePosition, Direction.WEST, 7).convert()).isEqualTo("d2");
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTHEAST, 7).convert()).isEqualTo("f3");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHEAST, 7).convert()).isEqualTo("f1");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHWEST, 7).convert()).isEqualTo("d1");
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTHWEST, 7).convert()).isEqualTo("d3");
+        //when
+        Position nextPosition = king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 7);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
     }
 
     @ParameterizedTest
     @CsvSource({
             "e1,SOUTH", "a1,WEST", "a8,NORTH", "h8,EAST"
     })
-    @DisplayName("체스판 밖으로 움직이려고 시도하면 무시한다.")
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
     void kingMoveWhenBoardOutThenException(String sourcePosition, String rawDirection) {
         //given
         King king = King.createBlack();
 
         //when
-        Position nextPosition = king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 1);
+        Exception exception = catchException(
+                () -> king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 1));
 
         //then
-        assertThat(nextPosition.convert()).isEqualTo(sourcePosition);
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/KingTest.java
+++ b/src/test/java/com/seong/chess/pieces/KingTest.java
@@ -1,8 +1,8 @@
 package com.seong.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchException;
 
+import com.seong.chess.Position;
 import com.seong.chess.pieces.Piece.Direction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,29 +17,29 @@ class KingTest {
         King king = King.createBlack();
         String sourcePosition = "e2";
 
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTH).convert()).isEqualTo("e3");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTH).convert()).isEqualTo("e1");
-        assertThat(king.nextPosition(sourcePosition, Direction.EAST).convert()).isEqualTo("f2");
-        assertThat(king.nextPosition(sourcePosition, Direction.WEST).convert()).isEqualTo("d2");
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTHEAST).convert()).isEqualTo("f3");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHEAST).convert()).isEqualTo("f1");
-        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHWEST).convert()).isEqualTo("d1");
-        assertThat(king.nextPosition(sourcePosition, Direction.NORTHWEST).convert()).isEqualTo("d3");
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTH, 7).convert()).isEqualTo("e3");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTH, 7).convert()).isEqualTo("e1");
+        assertThat(king.nextPosition(sourcePosition, Direction.EAST, 7).convert()).isEqualTo("f2");
+        assertThat(king.nextPosition(sourcePosition, Direction.WEST, 7).convert()).isEqualTo("d2");
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTHEAST, 7).convert()).isEqualTo("f3");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHEAST, 7).convert()).isEqualTo("f1");
+        assertThat(king.nextPosition(sourcePosition, Direction.SOUTHWEST, 7).convert()).isEqualTo("d1");
+        assertThat(king.nextPosition(sourcePosition, Direction.NORTHWEST, 7).convert()).isEqualTo("d3");
     }
 
     @ParameterizedTest
     @CsvSource({
             "e1,SOUTH", "a1,WEST", "a8,NORTH", "h8,EAST"
     })
-    @DisplayName("체스판 밖으로 움직이면 예외가 발생한다.")
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 무시한다.")
     void kingMoveWhenBoardOutThenException(String sourcePosition, String rawDirection) {
         //given
         King king = King.createBlack();
 
         //when
-        Exception exception = catchException(() -> king.nextPosition(sourcePosition, Direction.valueOf(rawDirection)));
+        Position nextPosition = king.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 1);
 
         //then
-        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        assertThat(nextPosition.convert()).isEqualTo(sourcePosition);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/KnightTest.java
+++ b/src/test/java/com/seong/chess/pieces/KnightTest.java
@@ -1,0 +1,96 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.chess.Position;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class KnightTest {
+
+    @ParameterizedTest
+    @MethodSource("knightMove")
+    @DisplayName("나이트는 모든 방향으로 3칸씩 움직일 수 있다.")
+    void knightMove(String sourcePosition, Direction direction, String expectedPosition) {
+        //given
+        Knight knight = Knight.createWhite();
+
+        //when
+        Position nextPosition = knight.nextPosition(sourcePosition, direction, 1);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
+    }
+
+    private static Stream<Arguments> knightMove() {
+        return Stream.of(
+                Arguments.arguments("d4", Direction.NNE, "e6"),
+                Arguments.arguments("d4", Direction.EEN, "f5"),
+                Arguments.arguments("d4", Direction.EES, "f3"),
+                Arguments.arguments("d4", Direction.SSE, "e2"),
+                Arguments.arguments("d4", Direction.SSW, "c2"),
+                Arguments.arguments("d4", Direction.WWS, "b3"),
+                Arguments.arguments("d4", Direction.WWN, "b5"),
+                Arguments.arguments("d4", Direction.NNW, "c6")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("knightCanNotMoveRightAndDiagonalDirection")
+    @DisplayName("나이트는 정방향, 대각선으로 움직이려고 하면 예외가 발생한다.")
+    void knightCanNotMoveRightAndDiagonalDirection(Direction direction) {
+        //given
+        Knight knight = Knight.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> knight.nextPosition(sourcePosition, direction, 1));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> knightCanNotMoveRightAndDiagonalDirection() {
+        return Stream.of(
+                Arguments.arguments(Direction.NORTH),
+                Arguments.arguments(Direction.SOUTH),
+                Arguments.arguments(Direction.EAST),
+                Arguments.arguments(Direction.WEST),
+                Arguments.arguments(Direction.NORTHEAST),
+                Arguments.arguments(Direction.SOUTHEAST),
+                Arguments.arguments(Direction.SOUTHWEST),
+                Arguments.arguments(Direction.NORTHWEST)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("knightMoveOverChessBoardThenException")
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
+    void knightMoveOverChessBoardThenException(String sourcePosition, Direction direction) {
+        //given
+        Knight knight = Knight.createBlack();
+
+        //when
+        Exception exception = catchException(() -> knight.nextPosition(sourcePosition, direction, 1));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> knightMoveOverChessBoardThenException() {
+        return Stream.of(
+                Arguments.arguments("d8", Direction.NNE),
+                Arguments.arguments("d8", Direction.NNW),
+                Arguments.arguments("d8", Direction.EEN),
+                Arguments.arguments("d8", Direction.WWN),
+                Arguments.arguments("a1", Direction.SSE),
+                Arguments.arguments("a1", Direction.SSW),
+                Arguments.arguments("a1", Direction.WWS),
+                Arguments.arguments("a1", Direction.EES)
+        );
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/PawnTest.java
+++ b/src/test/java/com/seong/chess/pieces/PawnTest.java
@@ -1,0 +1,103 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.chess.Position;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PawnTest {
+
+    @Nested
+    @DisplayName("폰의 움직임은 ")
+    class PawnMove {
+
+        @ParameterizedTest
+        @CsvSource({"a2,1,a3", "a2,2,a4"})
+        @DisplayName("초기 상태에서는 1칸 또는 2칸을 움직일 수 있다.")
+        void oneOrTwoWhenInitialState(String sourcePosition, int moveCount, String expectedPosition) {
+            //given
+            Pawn pawn = Pawn.createWhite();
+
+            //when
+            Position nextPosition = pawn.nextPosition(sourcePosition, Direction.NORTH, moveCount);
+
+            //then
+            assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
+        }
+
+        @Test
+        @DisplayName("예외(IllegalArgument): 초기 상태가 아니면 2칸 움직일 수 없다.")
+        void illegalArgument_WhenMoveTwoButNotInitialState() {
+            //given
+            Pawn pawn = Pawn.createWhite();
+
+            //when
+            Exception exception = catchException(() -> pawn.nextPosition("a3", Direction.NORTH, 2));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @ParameterizedTest
+        @MethodSource("illegalArgument_WhiteOnlyCanMoveToNorth")
+        @DisplayName("예외(IllegalArgument): 흰색은 북쪽 외의 방향으로는 움직일 수 없다.")
+        void illegalArgument_WhiteOnlyCanMoveToNorth(Direction direction) {
+            //given
+            Pawn pawn = Pawn.createWhite();
+
+            //when
+            Exception exception = catchException(() -> pawn.nextPosition("d4", direction, 1));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        private static Stream<Arguments> illegalArgument_WhiteOnlyCanMoveToNorth() {
+            return Arrays.stream(Direction.values())
+                    .filter(direction -> direction != Direction.NORTH)
+                    .map(Arguments::arguments);
+        }
+
+        @ParameterizedTest
+        @MethodSource("illegalArgument_WhiteOnlyCanMoveToSouth")
+        @DisplayName("예외(IllegalArgument): 검은색은 남쪽 외의 방향으로는 움직일 수 없다.")
+        void illegalArgument_WhiteOnlyCanMoveToSouth(Direction direction) {
+            //given
+            Pawn pawn = Pawn.createBlack();
+
+            //when
+            Exception exception = catchException(() -> pawn.nextPosition("d6", direction, 1));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        private static Stream<Arguments> illegalArgument_WhiteOnlyCanMoveToSouth() {
+            return Arrays.stream(Direction.values())
+                    .filter(direction -> direction != Direction.SOUTH)
+                    .map(Arguments::arguments);
+        }
+
+        @Test
+        @DisplayName("예외(IllegalArgument): 체스판 밖으로 이동할 수 없다.")
+        void illegalArgument_WhenPawnMoveOverChessBoard() {
+            //given
+            Pawn pawn = Pawn.createWhite();
+
+            //when
+            Exception exception = catchException(() -> pawn.nextPosition("d8", Direction.NORTH, 1));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/QueenTest.java
+++ b/src/test/java/com/seong/chess/pieces/QueenTest.java
@@ -1,0 +1,43 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.seong.chess.Position;
+import com.seong.chess.pieces.Piece.Direction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class QueenTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "d5,NORTH,d8", "d5,SOUTH,d1", "d5,WEST,a5", "d5,EAST,h5",
+            "d5,NORTHEAST,g8", "d5,SOUTHEAST,h1", "d5,SOUTHWEST,a2", "d5,NORTHWEST,a8"
+    })
+    @DisplayName("퀸은 모든 방향으로 이동할 수 있다.")
+    void moveQueen(String sourcePosition, String rawDirection, String expectedPosition) {
+        //given
+        Queen queen = Queen.createBlack();
+
+        //when
+        Position nextPosition = queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 10);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
+    }
+
+    @Test
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 무시한다.")
+    void moveQueenOverChessBoard() {
+        //given
+        Queen queen = Queen.createBlack();
+
+        //when
+        Position nextPosition = queen.nextPosition("a1", Direction.NORTH, 100);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo("a8");
+    }
+}

--- a/src/test/java/com/seong/chess/pieces/QueenTest.java
+++ b/src/test/java/com/seong/chess/pieces/QueenTest.java
@@ -1,43 +1,42 @@
 package com.seong.chess.pieces;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.chess.Position;
-import com.seong.chess.pieces.Piece.Direction;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class QueenTest {
 
     @ParameterizedTest
-    @CsvSource({
-            "d5,NORTH,d8", "d5,SOUTH,d1", "d5,WEST,a5", "d5,EAST,h5",
-            "d5,NORTHEAST,g8", "d5,SOUTHEAST,h1", "d5,SOUTHWEST,a2", "d5,NORTHWEST,a8"
-    })
+    @CsvSource({"d5,NORTH,3,d8", "d5,SOUTH,4,d1", "d5,WEST,3,a5", "d5,EAST,4,h5", "d5,NORTHEAST,3,g8",
+            "d5,SOUTHEAST,4,h1", "d5,SOUTHWEST,3,a2", "d5,NORTHWEST,3,a8"})
     @DisplayName("퀸은 모든 방향으로 이동할 수 있다.")
-    void moveQueen(String sourcePosition, String rawDirection, String expectedPosition) {
+    void moveQueen(String sourcePosition, String rawDirection, int moveCount, String expectedPosition) {
         //given
         Queen queen = Queen.createBlack();
 
         //when
-        Position nextPosition = queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), 10);
+        Position nextPosition = queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), moveCount);
 
         //then
         assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
     }
 
-    @Test
-    @DisplayName("체스판 밖으로 움직이려고 시도하면 무시한다.")
-    void moveQueenOverChessBoard() {
+    @ParameterizedTest
+    @CsvSource({"d5,NORTH,100", "d5,SOUTH,100", "d5,WEST,100", "d5,EAST,100"})
+    @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
+    void moveQueenOverChessBoard(String sourcePosition, String rawDirection, int moveCount) {
         //given
         Queen queen = Queen.createBlack();
 
         //when
-        Position nextPosition = queen.nextPosition("a1", Direction.NORTH, 100);
+        Exception exception = catchException(
+                () -> queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), moveCount));
 
         //then
-        assertThat(nextPosition.convert()).isEqualTo("a8");
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/QueenTest.java
+++ b/src/test/java/com/seong/chess/pieces/QueenTest.java
@@ -4,39 +4,82 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
 import com.seong.chess.Position;
+import java.util.Arrays;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class QueenTest {
 
     @ParameterizedTest
-    @CsvSource({"d5,NORTH,3,d8", "d5,SOUTH,4,d1", "d5,WEST,3,a5", "d5,EAST,4,h5", "d5,NORTHEAST,3,g8",
-            "d5,SOUTHEAST,4,h1", "d5,SOUTHWEST,3,a2", "d5,NORTHWEST,3,a8"})
-    @DisplayName("퀸은 모든 방향으로 이동할 수 있다.")
-    void moveQueen(String sourcePosition, String rawDirection, int moveCount, String expectedPosition) {
+    @MethodSource("moveQueen")
+    @DisplayName("퀸은 정방향, 대각선으로 이동할 수 있다.")
+    void moveQueen(String sourcePosition, Direction direction, int moveCount, String expectedPosition) {
         //given
         Queen queen = Queen.createBlack();
 
         //when
-        Position nextPosition = queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), moveCount);
+        Position nextPosition = queen.nextPosition(sourcePosition, direction, moveCount);
 
         //then
         assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
     }
 
+    private static Stream<Arguments> moveQueen() {
+        return Stream.of(
+                Arguments.arguments("d5", Direction.NORTH, 3, "d8"),
+                Arguments.arguments("d5", Direction.SOUTH, 4, "d1"),
+                Arguments.arguments("d5", Direction.EAST, 4, "h5"),
+                Arguments.arguments("d5", Direction.WEST, 3, "a5"),
+                Arguments.arguments("d5", Direction.NORTHEAST, 3, "g8"),
+                Arguments.arguments("d5", Direction.SOUTHEAST, 4, "h1"),
+                Arguments.arguments("d5", Direction.SOUTHWEST, 3, "a2"),
+                Arguments.arguments("d5", Direction.NORTHWEST, 3, "a8")
+        );
+    }
+
     @ParameterizedTest
-    @CsvSource({"d5,NORTH,100", "d5,SOUTH,100", "d5,WEST,100", "d5,EAST,100"})
+    @MethodSource("queenDirection")
     @DisplayName("체스판 밖으로 움직이려고 시도하면 예외가 발생한다.")
-    void moveQueenOverChessBoard(String sourcePosition, String rawDirection, int moveCount) {
+    void queenDirection(Direction direction) {
         //given
         Queen queen = Queen.createBlack();
+        String sourcePosition = "d5";
 
         //when
         Exception exception = catchException(
-                () -> queen.nextPosition(sourcePosition, Direction.valueOf(rawDirection), moveCount));
+                () -> queen.nextPosition(sourcePosition, direction, 100));
 
         //then
         assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> queenDirection() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> direction.isRight() || direction.isDiagonal())
+                .map(Arguments::arguments);
+    }
+
+    @ParameterizedTest
+    @MethodSource("queenOnlyMoveRightAndDiagonalDirection")
+    @DisplayName("퀸은 정방향, 대각선 이외의 방향으로 움직이려고 시도하면 예외가 발생한다.")
+    void queenOnlyMoveRightAndDiagonalDirection(Direction direction) {
+        //given
+        Queen queen = Queen.createWhite();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> queen.nextPosition(sourcePosition, direction, 1));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> queenOnlyMoveRightAndDiagonalDirection() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> !(direction.isRight() || direction.isDiagonal()))
+                .map(Arguments::arguments);
     }
 }

--- a/src/test/java/com/seong/chess/pieces/RookTest.java
+++ b/src/test/java/com/seong/chess/pieces/RookTest.java
@@ -1,0 +1,81 @@
+package com.seong.chess.pieces;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import com.seong.chess.Position;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RookTest {
+
+    @ParameterizedTest
+    @MethodSource("rookMove")
+    @DisplayName("룩은 정방향으로 움직일 수 있다.")
+    void rookMove(String sourcePosition, Direction direction, int moveCount, String expectedPosition) {
+        //given
+        Rook rook = Rook.createBlack();
+
+        //when
+        Position nextPosition = rook.nextPosition(sourcePosition, direction, moveCount);
+
+        //then
+        assertThat(nextPosition.convert()).isEqualTo(expectedPosition);
+    }
+
+    private static Stream<Arguments> rookMove() {
+        return Stream.of(
+                Arguments.arguments("d5", Direction.NORTH, 3, "d8"),
+                Arguments.arguments("d5", Direction.SOUTH, 4, "d1"),
+                Arguments.arguments("d5", Direction.EAST, 4, "h5"),
+                Arguments.arguments("d5", Direction.WEST, 3, "a5")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("rookOnlyMoveRightDirectionButOthersException")
+    @DisplayName("룩은 정방향 이외의 방향으로 움직이면 예외가 발생한다.")
+    void rookOnlyMoveRightDirectionButOthersException(Direction direction) {
+        //given
+        Rook rook = Rook.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> rook.nextPosition(sourcePosition, direction, 1));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    private static Stream<Arguments> rookOnlyMoveRightDirectionButOthersException() {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> !direction.isRight())
+                .map(Arguments::arguments);
+    }
+
+    @ParameterizedTest
+    @MethodSource("rookMoveOverChessBoardThenException")
+    @DisplayName("체스판 밖으로 이동하려고 시도하면 예외가 발생한다.")
+    void rookMoveOverChessBoardThenException(Direction direction) {
+        //given
+        Rook rook = Rook.createBlack();
+        String sourcePosition = "d4";
+
+        //when
+        Exception exception = catchException(() -> rook.nextPosition(sourcePosition, direction, 100));
+
+        //then
+        assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static Stream<Arguments> rookMoveOverChessBoardThenException() {
+        return Arrays.stream(Direction.values())
+                .filter(Direction::isRight)
+                .map(Arguments::arguments);
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 체스 기물들의 이동을 구현하였습니다.
  - 기물의 움직임은 `ChessGame`에서 결정합니다.
  - 기물이 입력으로 주어진 방향, 횟수만큼 이동할 수 있는지 여부는 각 기물들이 판단합니다.
  - 부모 클래스 `Piece`의 `nextPosition()`은 재귀를 이용해 해당하는 위치로 이동할 수 있는지 판단합니다.
    - 나이트, 폰, 킹과 같이 움직임이 특수하거나, 단순한 경우 자식 클래스에서 재정의했습니다.
    - 입력으로 주어진 방향으로 이동할 수 있는지 판단하는 `checkPieceCanMove()`는 추상 메서드로 선언하여 자식 클래스에서 재정의합니다.
- 체스 보드로부터 체스 게임과 관련된 로직을 `ChessGame`으로 분리하였습니다.
  - 체스 기물의 이동, 게임 초기화, 점수 계산과 같이 게임과 관련된 로직은 `ChessGame`에서 처리합니다.

## 고민 사항
- 체스 기물은 주어진 위치에서 입력으로 주어진 방향, 값만큼 이동할 수 있는지 없는지만 판단하고, 자신의 명시적인 위치는 모르도록 하였습니다. 기물의 위치를 알고 이동에 대한 판단을 하는 것은 오직 체스보드일 것이라고 생각하였습니다.
- 내부 정적 클래스의 길이가 길어지면 외부 클래스의 길이도 함께 길어져서 어느 시점엔가 별도의 클래스로 분리시키는 것이 보기 편하다는 생각이 듭니다. 적절한 시점이 언제일지, 처음부터 내부 클래스보다는 동일한 패키지에 두는 선택을 하는 것이 나을지 고민하고 있습니다.

## 기타
