### PR TITLE
[i960107] step-6 기물 이동 구현

### DIFF
--- a/src/main/java/chess/Application.java
+++ b/src/main/java/chess/Application.java
@@ -2,11 +2,16 @@ package chess;
 
 import chess.board.Board;
 import chess.pieces.Position;
+import chess.view.ChessView;
 import java.util.Arrays;
 import java.util.Scanner;
 
 public class Application {
+
     private static Board board;
+
+    private static ChessView chessView;
+
 
     enum GameControlCommand {
         START, END, MOVE;
@@ -65,13 +70,14 @@ public class Application {
     private static void startGame() {
         board = new Board();
         board.initialize();
-        board.print();
+        chessView = new ChessView();
+        chessView.print(board);
     }
 
     private static void movePiece(String originalCommand) {
         String[] token = originalCommand.split(" ");
         board.move(Position.fromString(token[1]), Position.fromString(token[2]));
-        board.print();
+        chessView.print(board);
     }
 
 

--- a/src/main/java/chess/Application.java
+++ b/src/main/java/chess/Application.java
@@ -1,18 +1,20 @@
 package chess;
 
 import chess.board.Board;
+import chess.pieces.Position;
 import java.util.Arrays;
 import java.util.Scanner;
 
 public class Application {
+    private static Board board;
 
     enum GameControlCommand {
-        START, END;
+        START, END, MOVE;
 
 
         public static GameControlCommand valueOfIgnoreCase(String command) {
             return Arrays.stream(GameControlCommand.values())
-                    .filter(c -> c.name().toLowerCase().equals(command))
+                    .filter(c -> command.startsWith(c.name().toLowerCase()))
                     .findFirst()
                     .orElseThrow(() -> new IllegalArgumentException("잘못된 command 입니다."));
         }
@@ -23,13 +25,13 @@ public class Application {
         try (Scanner scanner = new Scanner(System.in)) {
             boolean continueRunning = true;
             while (continueRunning) {
-                System.out.print("start/end 입력: ");
+                System.out.print("start/end/move src dest 입력: ");
                 String input = scanner.nextLine();
                 GameControlCommand command = getGameControlCommand(input);
                 if (command == null) {
                     continue;
                 }
-                continueRunning = execute(command);
+                continueRunning = execute(command, input);
             }
         }
 
@@ -46,10 +48,14 @@ public class Application {
         return command;
     }
 
-    private static boolean execute(GameControlCommand command) {
+    private static boolean execute(GameControlCommand command, String originalCommand) {
         return switch (command) {
             case START -> {
                 startGame();
+                yield true;
+            }
+            case MOVE -> {
+                movePiece(originalCommand);
                 yield true;
             }
             case END -> false;
@@ -57,9 +63,16 @@ public class Application {
     }
 
     private static void startGame() {
-        Board board = new Board();
+        board = new Board();
         board.initialize();
         board.print();
     }
+
+    private static void movePiece(String originalCommand) {
+        String[] token = originalCommand.split(" ");
+        board.move(Position.fromString(token[1]), Position.fromString(token[2]));
+        board.print();
+    }
+
 
 }

--- a/src/main/java/chess/ChessGame.java
+++ b/src/main/java/chess/ChessGame.java
@@ -1,0 +1,23 @@
+package chess;
+
+import chess.calculator.DefaultPointCalculateStrategy;
+import chess.calculator.PointCalculator;
+import chess.calculator.SameFilePawnPointCalculateStrategy;
+import chess.pieces.Piece.Color;
+import java.util.List;
+
+public class ChessGame {
+    private final PointCalculator pointCalculator;
+
+    public ChessGame() {
+        this.pointCalculator = new PointCalculator(List.of(
+                new DefaultPointCalculateStrategy(),
+                new SameFilePawnPointCalculateStrategy()
+        ));
+    }
+
+    public double calculatePoint(Color color) {
+        return 0;
+//        return pointCalculator.calculate(this, color);
+    }
+}

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -1,6 +1,8 @@
 package chess.board;
 
+import static chess.board.Rank.getBlackPawnRank;
 import static chess.board.Rank.getBlankRank;
+import static chess.board.Rank.getWhitePawnRank;
 
 import chess.calculator.DefaultPointCalculateStrategy;
 import chess.calculator.PointCalculator;
@@ -12,6 +14,7 @@ import chess.pieces.Position;
 import chess.sorter.Direction;
 import chess.sorter.Sorter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import utils.StringUtils;
@@ -23,8 +26,6 @@ public class Board {
     public static final int FILE_COUNT = 8;
 
     private final List<Rank> ranks;
-
-    private int pieceCount;
 
     private final PointCalculator pointCalculator;
 
@@ -60,10 +61,6 @@ public class Board {
         return RANK_COUNT * FILE_COUNT;
     }
 
-    public int pieceCount() {
-        return pieceCount;
-    }
-
     public int pieceCount(Type type, Color color) {
         return ranks.stream()
                 .mapToInt(rank -> rank.count(type, color))
@@ -71,7 +68,7 @@ public class Board {
     }
 
     public void initialize() {
-        initializeRank(0, new Rank(FILE_COUNT, List.of(
+        initializeRank(0, new Rank(FILE_COUNT, Arrays.asList(
                 Piece.createWhiteRook(),
                 Piece.createWhiteKnight(),
                 Piece.createWhiteBishop(),
@@ -81,31 +78,13 @@ public class Board {
                 Piece.createWhiteKnight(),
                 Piece.createWhiteRook()
         )));
-        initializeRank(1, new Rank(FILE_COUNT, List.of(
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn(),
-                Piece.createWhitePawn()
-        )));
+        initializeRank(1, getWhitePawnRank(FILE_COUNT));
         initializeRank(2, getBlankRank(FILE_COUNT));
         initializeRank(3, getBlankRank(FILE_COUNT));
         initializeRank(4, getBlankRank(FILE_COUNT));
         initializeRank(5, getBlankRank(FILE_COUNT));
-        initializeRank(6, new Rank(FILE_COUNT, List.of(
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn(),
-                Piece.createBlackPawn()
-        )));
-        initializeRank(7, new Rank(FILE_COUNT, List.of(
+        initializeRank(6, getBlackPawnRank(FILE_COUNT));
+        initializeRank(7, new Rank(FILE_COUNT, Arrays.asList(
                 Piece.createBlackRook(),
                 Piece.createBlackKnight(),
                 Piece.createBlackBishop(),
@@ -117,14 +96,10 @@ public class Board {
         )));
     }
 
-
     private void initializeRank(int rankNum, Rank rank) {
-        rank.getPieces()
-                .forEach(piece -> {
-                    if (!piece.isBlank()) {
-                        pieceCount += 1;
-                    }
-                });
+        if (rankNum >= RANK_COUNT) {
+            throw new IllegalArgumentException();
+        }
         ranks.set(rankNum, rank);
     }
 

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -1,8 +1,8 @@
 package chess.board;
 
-import static chess.board.Rank.getBlackPawnRank;
-import static chess.board.Rank.getBlankRank;
-import static chess.board.Rank.getWhitePawnRank;
+import static chess.board.Rank.createBlackPawnRank;
+import static chess.board.Rank.createBlankRank;
+import static chess.board.Rank.createWhitePawnRank;
 
 import chess.calculator.DefaultPointCalculateStrategy;
 import chess.calculator.PointCalculator;
@@ -78,12 +78,12 @@ public class Board {
                 Piece.createWhiteKnight(),
                 Piece.createWhiteRook()
         )));
-        initializeRank(1, getWhitePawnRank(FILE_COUNT));
-        initializeRank(2, getBlankRank(FILE_COUNT));
-        initializeRank(3, getBlankRank(FILE_COUNT));
-        initializeRank(4, getBlankRank(FILE_COUNT));
-        initializeRank(5, getBlankRank(FILE_COUNT));
-        initializeRank(6, getBlackPawnRank(FILE_COUNT));
+        initializeRank(1, createWhitePawnRank(FILE_COUNT));
+        initializeRank(2, createBlankRank(FILE_COUNT));
+        initializeRank(3, createBlankRank(FILE_COUNT));
+        initializeRank(4, createBlankRank(FILE_COUNT));
+        initializeRank(5, createBlankRank(FILE_COUNT));
+        initializeRank(6, createBlackPawnRank(FILE_COUNT));
         initializeRank(7, new Rank(FILE_COUNT, Arrays.asList(
                 Piece.createBlackRook(),
                 Piece.createBlackKnight(),
@@ -106,7 +106,7 @@ public class Board {
 
     public void initializeEmpty() {
         for (int rankNum = 0; rankNum < RANK_COUNT; rankNum++) {
-            ranks.set(rankNum, getBlankRank(FILE_COUNT));
+            ranks.set(rankNum, createBlankRank(FILE_COUNT));
         }
     }
 
@@ -126,6 +126,14 @@ public class Board {
     public void move(Position position, Piece piece) {
         Rank rank = getRank(position);
         rank.set(position.getFileNumber(), piece);
+    }
+
+    public void move(Position source, Position target) {
+        Rank sourceRank = getRank(source);
+        Piece piece = sourceRank.removePiece(source.getFileNumber());
+
+        Rank targetRank = getRank(target);
+        targetRank.set(target.getFileNumber(), piece);
     }
 
     public double calculatePoint(Color color) {

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import utils.StringUtils;
 
 public class Board {
 
@@ -50,7 +49,7 @@ public class Board {
         return ranks.get(position.getRankNumber());
     }
 
-    private Rank getRank(int rankNum) {
+    public Rank getRank(int rankNum) {
         if (rankNum < 0 || rankNum >= RANK_COUNT) {
             throw new IllegalArgumentException();
         }
@@ -108,19 +107,6 @@ public class Board {
         for (int rankNum = 0; rankNum < RANK_COUNT; rankNum++) {
             ranks.set(rankNum, createBlankRank(FILE_COUNT));
         }
-    }
-
-    public void print() {
-        System.out.println(showBoard());
-    }
-
-    public String showBoard() {
-        StringBuilder sb = new StringBuilder();
-        for (int rankNum = RANK_COUNT - 1; rankNum >= 0; rankNum--) {
-            StringBuilder rank = StringUtils.appendNewLine(getRank(rankNum).show());
-            sb.append(rank);
-        }
-        return sb.toString();
     }
 
     public void move(Position position, Piece piece) {

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -28,18 +28,12 @@ public class Board {
 
     private final PointCalculator pointCalculator;
 
-    private final List<Piece> blackPieces;
-
-    private final List<Piece> whitePieces;
-
     public Board() {
         this.ranks = new ArrayList<>(Collections.nCopies(RANK_COUNT, null));
         pointCalculator = new PointCalculator(List.of(
                 new DefaultPointCalculateStrategy(),
                 new SameFilePawnPointCalculateStrategy()
         ));
-        blackPieces = new ArrayList<>();
-        whitePieces = new ArrayList<>();
     }
 
 
@@ -129,18 +123,9 @@ public class Board {
                 .forEach(piece -> {
                     if (!piece.isBlank()) {
                         pieceCount += 1;
-                        addPieces(piece);
                     }
                 });
         ranks.set(rankNum, rank);
-    }
-
-    private void addPieces(Piece piece) {
-        if (piece.isBlack()) {
-            blackPieces.add(piece);
-        } else if (piece.isWhite()) {
-            whitePieces.add(piece);
-        }
     }
 
 
@@ -173,18 +158,15 @@ public class Board {
     }
 
     public List<Piece> sort(Color color, Sorter sorter, Direction direction) {
-        List<Piece> sorted;
-        if (direction.equals(Direction.ASC)) {
-            sorted = sorter.sortAsc(this, color);
-        } else {
-            sorted = sorter.sortDesc(this, color);
-        }
+        List<Piece> sorted = sorter.sort(getPieces(color), direction);
         return Collections.unmodifiableList(sorted);
     }
 
     public List<Piece> getPieces(Color color) {
-        List<Piece> pieces = color.equals(Color.WHITE) ? whitePieces : blackPieces;
-        return Collections.unmodifiableList(pieces);
+        return ranks.stream()
+                .map(rank -> rank.getPieces(color))
+                .flatMap(List::stream)
+                .toList();
     }
 
 }

--- a/src/main/java/chess/board/Rank.java
+++ b/src/main/java/chess/board/Rank.java
@@ -71,4 +71,17 @@ public class Rank {
                 .filter(piece -> piece.hasColor(color))
                 .count();
     }
+
+    public void set(int fileNum, Piece piece) {
+        if (fileNum >= size || piece == null) {
+            throw new IllegalArgumentException();
+        }
+        pieces.set(fileNum, piece);
+    }
+
+    public Piece removePiece(int fileNum) {
+        Piece piece = findPiece(fileNum);
+        set(fileNum, Piece.createBlank());
+        return piece;
+    }
 }

--- a/src/main/java/chess/board/Rank.java
+++ b/src/main/java/chess/board/Rank.java
@@ -6,6 +6,7 @@ import chess.pieces.Piece.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class Rank {
 
@@ -14,11 +15,31 @@ public class Rank {
     private List<Piece> pieces;
 
     public Rank(int size, List<Piece> rank) {
-        if (size == 0 || rank.size() != size) {
+        if (size == 0 || rank == null || rank.size() != size) {
             throw new IllegalArgumentException();
         }
         this.size = size;
         this.pieces = rank;
+    }
+
+    public static Rank createRank(int size, Supplier<Piece> supplier) {
+        List<Piece> pieces = new ArrayList<>();
+        for (int count = 0; count < size; count++) {
+            pieces.add(supplier.get());
+        }
+        return new Rank(size, pieces);
+    }
+
+    public static Rank createWhitePawnRank(int size) {
+        return createRank(size, Piece::createWhitePawn);
+    }
+
+    public static Rank createBlackPawnRank(int size) {
+        return createRank(size, Piece::createBlackPawn);
+    }
+
+    public static Rank createBlankRank(int size) {
+        return createRank(size, Piece::createBlank);
     }
 
     public Piece findPiece(int fileNum) {
@@ -34,13 +55,6 @@ public class Rank {
         return sb;
     }
 
-    public void set(int fileNum, Piece piece) {
-        if (fileNum >= size || piece == null) {
-            throw new IllegalArgumentException();
-        }
-        pieces.set(fileNum, piece);
-    }
-
     public List<Piece> getPieces() {
         return Collections.unmodifiableList(pieces);
     }
@@ -49,14 +63,6 @@ public class Rank {
         return pieces.stream()
                 .filter(p -> p.hasColor(color))
                 .toList();
-    }
-
-    public static Rank getBlankRank(int size) {
-        List<Piece> pieces = new ArrayList<>();
-        for (int count = 0; count < size; count++) {
-            pieces.add(Piece.createBlank());
-        }
-        return new Rank(size, pieces);
     }
 
     public int count(Type type, Color color) {

--- a/src/main/java/chess/board/Rank.java
+++ b/src/main/java/chess/board/Rank.java
@@ -45,6 +45,12 @@ public class Rank {
         return Collections.unmodifiableList(pieces);
     }
 
+    public List<Piece> getPieces(Color color) {
+        return pieces.stream()
+                .filter(p -> p.hasColor(color))
+                .toList();
+    }
+
     public static Rank getBlankRank(int size) {
         List<Piece> pieces = new ArrayList<>();
         for (int count = 0; count < size; count++) {

--- a/src/main/java/chess/board/Rank.java
+++ b/src/main/java/chess/board/Rank.java
@@ -3,6 +3,7 @@ package chess.board;
 import chess.pieces.Piece;
 import chess.pieces.Piece.Color;
 import chess.pieces.Piece.Type;
+import chess.pieces.PieceFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,15 +32,15 @@ public class Rank {
     }
 
     public static Rank createWhitePawnRank(int size) {
-        return createRank(size, Piece::createWhitePawn);
+        return createRank(size, PieceFactory::createWhitePawn);
     }
 
     public static Rank createBlackPawnRank(int size) {
-        return createRank(size, Piece::createBlackPawn);
+        return createRank(size, PieceFactory::createBlackPawn);
     }
 
     public static Rank createBlankRank(int size) {
-        return createRank(size, Piece::createBlank);
+        return createRank(size, PieceFactory::createBlankPiece);
     }
 
     public Piece findPiece(int fileNum) {
@@ -77,11 +78,5 @@ public class Rank {
             throw new IllegalArgumentException();
         }
         pieces.set(fileNum, piece);
-    }
-
-    public Piece removePiece(int fileNum) {
-        Piece piece = findPiece(fileNum);
-        set(fileNum, Piece.createBlank());
-        return piece;
     }
 }

--- a/src/main/java/chess/pieces/Bishop.java
+++ b/src/main/java/chess/pieces/Bishop.java
@@ -1,0 +1,13 @@
+package chess.pieces;
+
+public class Bishop extends Piece {
+
+    protected Bishop(Color color) {
+        super(color, Type.BISHOP, Direction.bishopDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOfDiagonal(degree(src, target));
+    }
+}

--- a/src/main/java/chess/pieces/BlankPiece.java
+++ b/src/main/java/chess/pieces/BlankPiece.java
@@ -1,0 +1,20 @@
+package chess.pieces;
+
+import java.util.List;
+
+public class BlankPiece extends Piece {
+
+    protected BlankPiece() {
+        super(Color.NO_COLOR, Type.NO_PIECE, List.of());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return null;
+    }
+
+    @Override
+    protected void additionalCheck(Position src, Position target) {
+        throw new IllegalArgumentException();
+    }
+}

--- a/src/main/java/chess/pieces/Direction.java
+++ b/src/main/java/chess/pieces/Direction.java
@@ -1,0 +1,103 @@
+package chess.pieces;
+
+import chess.pieces.Position.Degree;
+import java.util.Arrays;
+import java.util.List;
+
+public enum Direction {
+    NORTH(0, 1),
+    NORTHEAST(1, 1),
+    EAST(1, 0),
+    SOUTHEAST(1, -1),
+    SOUTH(0, -1),
+    SOUTHWEST(-1, -1),
+    WEST(-1, 0),
+    NORTHWEST(-1, 1),
+
+    NNE(1, 2),
+    NNW(-1, 2),
+    SSE(1, -2),
+    SSW(-1, -2),
+    EEN(2, 1),
+    EES(2, -1),
+    WWN(-2, 1),
+    WWS(-2, -1);
+
+    private int xDegree;
+    private int yDegree;
+
+    Direction(int xDegree, int yDegree) {
+        this.xDegree = xDegree;
+        this.yDegree = yDegree;
+    }
+
+    public static List<Direction> rookDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST);
+    }
+
+    public static List<Direction> bishopDirection() {
+        return Arrays.asList(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST);
+    }
+
+    public static List<Direction> queenDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST);
+    }
+
+    public static List<Direction> knightDirection() {
+        return Arrays.asList(NNE, NNW, SSE, SSW, EEN, EES, WWN, WWS);
+    }
+
+    public static List<Direction> kingDirection() {
+        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST, SOUTH, SOUTHEAST, SOUTHWEST, EAST, WEST);
+    }
+
+    public static List<Direction> whitePawnDirection() {
+        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST);
+    }
+
+    public static List<Direction> blackPawnDirection() {
+        return Arrays.asList(SOUTH, SOUTHEAST, SOUTHWEST);
+    }
+
+    public int getXDegree() {
+        return xDegree;
+    }
+
+    public int getYDegree() {
+        return yDegree;
+    }
+
+    private static Direction valueOf(int xDegree, int yDegree) {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> direction.xDegree == xDegree && direction.yDegree == yDegree)
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public static Direction valueOf(Degree degree) {
+        return valueOf(degree.getXDegree(), degree.getYDegree());
+    }
+
+    public static Direction valueOfDiagonal(Degree degree) {
+        if (!degree.isDiagonal()) {
+            throw new IllegalArgumentException();
+        }
+        return valueOf(degree.getDegreeOne());
+    }
+
+    public static Direction valueOfLinear(Degree degree) {
+        if (!degree.isLinear()) {
+            throw new IllegalArgumentException();
+        }
+        return valueOf(degree.getDegreeOne());
+    }
+
+    public static Direction valueOfLEvery(Degree degree) {
+        try {
+            return valueOfLinear(degree);
+        } catch (IllegalArgumentException e) {
+            return valueOfDiagonal(degree);
+        }
+    }
+
+}

--- a/src/main/java/chess/pieces/King.java
+++ b/src/main/java/chess/pieces/King.java
@@ -1,0 +1,23 @@
+package chess.pieces;
+
+import chess.pieces.Position.Degree;
+
+public class King extends Piece {
+
+    protected King(Color color) {
+        super(color, Type.KING, Direction.kingDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOf(degree(src, target));
+    }
+
+    @Override
+    protected void additionalCheck(Position src, Position target) {
+        Degree degree = degree(src, target);
+        if (degree.isOverOneYDegree() || degree.isOverOneXDegree()) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/chess/pieces/Knight.java
+++ b/src/main/java/chess/pieces/Knight.java
@@ -1,0 +1,13 @@
+package chess.pieces;
+
+public class Knight extends Piece {
+
+    protected Knight(Color color) {
+        super(color, Type.KNIGHT, Direction.knightDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOf(degree(src, target));
+    }
+}

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -1,0 +1,33 @@
+package chess.pieces;
+
+public class Pawn extends Piece {
+    private static final int WHITE_STARTING_RANK_NUMBER = 1;
+    private static final int BLACK_STARTING_RANK_NUMBER = 6;
+
+    protected Pawn(Color color) {
+        super(color,
+                Type.PAWN,
+                color.equals(Color.WHITE) ? Direction.whitePawnDirection() : Direction.blackPawnDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOf(degree(src, target));
+    }
+
+    @Override
+    protected void additionalCheck(Position src, Position target) {
+        if (this.atStartingPoint(src)) {
+            return;
+        }
+        if (degree(src, target).isOverOneYDegree()) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private boolean atStartingPoint(Position position) {
+        return (this.isWhite() && position.getRankNumber() == WHITE_STARTING_RANK_NUMBER) ||
+                (this.isBlack() && position.getRankNumber() == BLACK_STARTING_RANK_NUMBER);
+
+    }
+}

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -1,12 +1,22 @@
 package chess.pieces;
 
+import chess.pieces.Position.Degree;
+import java.util.List;
 import java.util.Objects;
 
-public class Piece {
+public abstract class Piece {
 
     private final Color color;
 
     private final Type type;
+
+    private final List<Direction> directionList;
+
+    protected Piece(Color color, Type type, List<Direction> directionList) {
+        this.color = color;
+        this.type = type;
+        this.directionList = directionList;
+    }
 
     public enum Color {
         BLACK, WHITE, NO_COLOR;
@@ -39,71 +49,6 @@ public class Piece {
         }
     }
 
-    private Piece(Color color, Type type) {
-        this.color = color;
-        this.type = type;
-    }
-
-    public static Piece createBlank() {
-        return new Piece(Color.NO_COLOR, Type.NO_PIECE);
-    }
-
-    public static Piece createWhitePawn() {
-        return createWhite(Type.PAWN);
-    }
-
-    public static Piece createBlackPawn() {
-        return createBlack(Type.PAWN);
-    }
-
-    public static Piece createWhiteKnight() {
-        return createWhite(Type.KNIGHT);
-    }
-
-    public static Piece createBlackKnight() {
-        return createBlack(Type.KNIGHT);
-    }
-
-    public static Piece createWhiteRook() {
-        return createWhite(Type.ROOK);
-    }
-
-    public static Piece createBlackRook() {
-        return createBlack(Type.ROOK);
-    }
-
-    public static Piece createWhiteBishop() {
-        return createWhite(Type.BISHOP);
-    }
-
-    public static Piece createBlackBishop() {
-        return createBlack(Type.BISHOP);
-    }
-
-    public static Piece createWhiteQueen() {
-        return createWhite(Type.QUEEN);
-    }
-
-    public static Piece createBlackQueen() {
-        return createBlack(Type.QUEEN);
-    }
-
-    public static Piece createWhiteKing() {
-        return createWhite(Type.KING);
-    }
-
-    public static Piece createBlackKing() {
-        return createBlack(Type.KING);
-    }
-
-    private static Piece createWhite(Type type) {
-        return new Piece(Color.WHITE, type);
-    }
-
-    private static Piece createBlack(Type type) {
-        return new Piece(Color.BLACK, type);
-    }
-
     public char getRepresentation() {
         return isBlack() ? type.getBlackRepresentation() : type.getWhiteRepresentation();
     }
@@ -133,6 +78,38 @@ public class Piece {
         return this.type.equals(type);
     }
 
+    public double getDefaultPoint() {
+        return this.type.defaultPoint;
+    }
+
+    public List<Position> getPath(Position src, Position target) {
+        additionalCheck(src, target);
+
+        Direction direction = direction(src, target);
+
+        if (!directionList.contains(direction)) {
+            throw new IllegalArgumentException();
+        }
+
+        return src.getPath(direction, target);
+    }
+
+    protected void additionalCheck(Position src, Position target) {
+        return;
+    }
+
+
+    abstract Direction direction(Position src, Position target);
+
+    protected Degree degree(Position src, Position target) {
+        return src.degree(target);
+    }
+
+    public boolean isSameTeam(Piece other) {
+        return (this.isWhite() && other.isWhite()) ||
+                (this.isBlack() && other.isBlack());
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -150,7 +127,4 @@ public class Piece {
         return Objects.hash(color, type);
     }
 
-    public double getDefaultPoint() {
-        return this.type.defaultPoint;
-    }
 }

--- a/src/main/java/chess/pieces/PieceFactory.java
+++ b/src/main/java/chess/pieces/PieceFactory.java
@@ -1,0 +1,59 @@
+package chess.pieces;
+
+import chess.pieces.Piece.Color;
+
+public class PieceFactory {
+    private static Piece BLANK_PIECE_INSTANCE = new BlankPiece();
+
+    public static Piece createWhiteRook() {
+        return new Rook(Color.WHITE);
+    }
+
+    public static Piece createBlackRook() {
+        return new Rook(Color.BLACK);
+    }
+
+    public static Piece createWhiteKing() {
+        return new King(Color.WHITE);
+    }
+
+    public static Piece createBlackKing() {
+        return new King(Color.BLACK);
+    }
+
+    public static Piece createWhiteQueen() {
+        return new Queen(Color.WHITE);
+    }
+
+    public static Piece createBlackQueen() {
+        return new Queen(Color.BLACK);
+    }
+
+    public static Piece createWhiteBishop() {
+        return new Bishop(Color.WHITE);
+    }
+
+    public static Piece createBlackBishop() {
+        return new Bishop(Color.BLACK);
+    }
+
+    public static Piece createWhiteKnight() {
+        return new Knight(Color.WHITE);
+    }
+
+    public static Piece createBlackKnight() {
+        return new Knight(Color.BLACK);
+    }
+
+    public static Piece createWhitePawn() {
+        return new Pawn(Color.WHITE);
+    }
+
+    public static Piece createBlackPawn() {
+        return new Pawn(Color.BLACK);
+    }
+
+    public static Piece createBlankPiece() {
+        return BLANK_PIECE_INSTANCE;
+    }
+}

--- a/src/main/java/chess/pieces/Position.java
+++ b/src/main/java/chess/pieces/Position.java
@@ -1,31 +1,120 @@
 package chess.pieces;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public enum Position {
-    a1, a2, a3, a4, a5, a6, a7, a8,
-    b1, b2, b3, b4, b5, b6, b7, b8,
-    c1, c2, c3, c4, c5, c6, c7, c8,
-    d1, d2, d3, d4, d5, d6, d7, d8,
-    e1, e2, e3, e4, e5, e6, e7, e8,
-    f1, f2, f3, f4, f5, f6, f7, f8,
-    g1, g2, g3, g4, g5, g6, g7, g8,
-    h1, h2, h3, h4, h5, h6, h7, h8;
+    a1(0, 0), a2(1, 0), a3(2, 0), a4(3, 0), a5(4, 0), a6(5, 0), a7(6, 0), a8(7, 0),
+    b1(0, 1), b2(1, 1), b3(2, 1), b4(3, 1), b5(4, 1), b6(5, 1), b7(6, 1), b8(7, 1),
+    c1(0, 2), c2(1, 2), c3(2, 2), c4(3, 2), c5(4, 2), c6(5, 2), c7(6, 2), c8(7, 2),
+    d1(0, 3), d2(1, 3), d3(2, 3), d4(3, 3), d5(4, 3), d6(5, 3), d7(6, 3), d8(7, 3),
+    e1(0, 4), e2(1, 4), e3(2, 4), e4(3, 4), e5(4, 4), e6(5, 4), e7(6, 4), e8(7, 4),
+    f1(0, 5), f2(1, 5), f3(2, 5), f4(3, 5), f5(4, 5), f6(5, 5), f7(6, 5), f8(7, 5),
+    g1(0, 6), g2(1, 6), g3(2, 6), g4(3, 6), g5(4, 6), g6(5, 6), g7(6, 6), g8(7, 6),
+    h1(0, 7), h2(1, 7), h3(2, 7), h4(3, 7), h5(4, 7), h6(5, 7), h7(6, 7), h8(7, 7);
 
-    public static final char MIN_FILE_CHAR = 'a';
+    private int rankNumber;
+    private int fileNumber;
+
+
+    Position(int rankNumber, int fileNumber) {
+        this.rankNumber = rankNumber;
+        this.fileNumber = fileNumber;
+    }
 
     public static Position fromString(String position) {
+        return Position.valueOf(position);
+    }
+
+    private static Position valueOf(int rankNumber, int fileNumber) {
+        //todo 검색 속도 개선하기
         return Arrays.stream(Position.values())
-                .filter(p -> p.name().equalsIgnoreCase(position))
+                .filter(p -> p.rankNumber == rankNumber && p.fileNumber == fileNumber)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 포지션 입니다"));
     }
 
+
     public int getRankNumber() {
-        return Character.getNumericValue(this.name().charAt(1)) - 1;
+        return rankNumber;
     }
 
     public int getFileNumber() {
-        return this.name().charAt(0) - MIN_FILE_CHAR;
+        return fileNumber;
+    }
+
+    public Degree degree(Position dest) {
+        return new Degree(dest.getFileNumber() - this.getFileNumber(), dest.getRankNumber() - this.getRankNumber());
+    }
+
+    public List<Position> getPath(Direction direction, Position target) {
+        List<Position> path = new ArrayList<>();
+        getPath(path, direction, this, target);
+        return path;
+    }
+
+    private void getPath(List<Position> path, Direction direction, Position src, Position target) {
+        if (src == target) {
+            return;
+        }
+        Position next = next(direction);
+        path.add(next);
+        getPath(path, direction, next, target);
+    }
+
+    private Position next(Direction direction) {
+        return Position.valueOf(rankNumber + direction.getYDegree(), fileNumber + direction.getXDegree());
+    }
+
+    public static class Degree {
+        private int xDegree;
+        private int yDegree;
+
+        public Degree(int xDegree, int yDegree) {
+            this.xDegree = xDegree;
+            this.yDegree = yDegree;
+        }
+
+        public int getXDegree() {
+            return xDegree;
+        }
+
+        public int getYDegree() {
+            return yDegree;
+        }
+
+        public Degree getDegreeOne() {
+            return new Degree(convertToOne(xDegree), convertToOne(yDegree));
+        }
+
+        public boolean isLinear() {
+            return xDegree == 0 || yDegree == 0;
+        }
+
+        public boolean isDiagonal() {
+            if (yDegree == 0) {
+                return false;
+            }
+            return xDegree % yDegree == 0;
+        }
+
+        public static int convertToOne(int number) {
+            if (number == 0) {
+                return 0;
+            }
+            if (number > 0) {
+                return 1;
+            }
+            return -1;
+        }
+
+        public boolean isOverOneYDegree() {
+            return yDegree > 1;
+        }
+
+        public boolean isOverOneXDegree() {
+            return xDegree > 1;
+        }
     }
 }

--- a/src/main/java/chess/pieces/Queen.java
+++ b/src/main/java/chess/pieces/Queen.java
@@ -1,0 +1,12 @@
+package chess.pieces;
+
+public class Queen extends Piece {
+    protected Queen(Color color) {
+        super(color, Type.QUEEN, Direction.queenDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOfLEvery(degree(src, target));
+    }
+}

--- a/src/main/java/chess/pieces/Rook.java
+++ b/src/main/java/chess/pieces/Rook.java
@@ -1,0 +1,13 @@
+package chess.pieces;
+
+public class Rook extends Piece {
+
+    protected Rook(Color color) {
+        super(color, Type.ROOK, Direction.rookDirection());
+    }
+
+    @Override
+    Direction direction(Position src, Position target) {
+        return Direction.valueOfLinear(degree(src, target));
+    }
+}

--- a/src/main/java/chess/sorter/PointSorter.java
+++ b/src/main/java/chess/sorter/PointSorter.java
@@ -1,25 +1,19 @@
 package chess.sorter;
 
-import chess.board.Board;
 import chess.pieces.Piece;
-import chess.pieces.Piece.Color;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class PointSorter implements Sorter {
+    private static final Comparator<Piece> ascComparator = Comparator.comparingDouble(Piece::getDefaultPoint);
+    private static final Comparator<Piece> descComparator = Comparator.comparingDouble(Piece::getDefaultPoint)
+            .reversed();
 
     @Override
-    public List<Piece> sortAsc(Board board, Color color) {
-        return board.getPieces(color).stream()
-                .sorted(Comparator.comparingDouble(Piece::getDefaultPoint))
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public List<Piece> sortDesc(Board board, Color color) {
-        return board.getPieces(color).stream()
-                .sorted(Comparator.comparingDouble(Piece::getDefaultPoint).reversed())
-                .collect(Collectors.toList());
+    public List<Piece> sort(List<Piece> pieces, Direction direction) {
+        Comparator<Piece> comparator = direction.equals(Direction.ASC) ? ascComparator : descComparator;
+        return pieces.stream()
+                .sorted(comparator)
+                .toList();
     }
 }

--- a/src/main/java/chess/sorter/Sorter.java
+++ b/src/main/java/chess/sorter/Sorter.java
@@ -1,13 +1,8 @@
 package chess.sorter;
 
-import chess.board.Board;
 import chess.pieces.Piece;
-import chess.pieces.Piece.Color;
 import java.util.List;
 
 public interface Sorter {
-    List<Piece> sortAsc(Board board, Color color);
-
-    List<Piece> sortDesc(Board board, Color color);
-
+    List<Piece> sort(List<Piece> pieces, Direction direction);
 }

--- a/src/main/java/chess/view/ChessView.java
+++ b/src/main/java/chess/view/ChessView.java
@@ -1,0 +1,20 @@
+package chess.view;
+
+import chess.board.Board;
+import utils.StringUtils;
+
+public class ChessView {
+
+    public void print(Board board) {
+        System.out.println(showBoard(board));
+    }
+
+    public String showBoard(Board board) {
+        StringBuilder sb = new StringBuilder();
+        for (int rankNum = Board.RANK_COUNT - 1; rankNum >= 0; rankNum--) {
+            StringBuilder rank = StringUtils.appendNewLine(board.getRank(rankNum).show());
+            sb.append(rank);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -12,6 +12,7 @@ import chess.pieces.Position;
 import chess.sorter.Direction;
 import chess.sorter.PointSorter;
 import chess.sorter.Sorter;
+import chess.view.ChessView;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,7 +51,10 @@ class BoardTest {
 
     private static Piece blankPiece;
 
+    private static ChessView chessView;
+
     private Board board;
+
 
     @BeforeAll
     static void beforeAll() {
@@ -67,6 +71,7 @@ class BoardTest {
         whiteKing = Piece.createWhiteKing();
         blackKing = Piece.createBlackKing();
         blankPiece = Piece.createBlank();
+        chessView = new ChessView();
     }
 
     @BeforeEach
@@ -85,7 +90,7 @@ class BoardTest {
                         blankRank + blankRank + blankRank + blankRank +
                         appendNewLine("pppppppp") +
                         appendNewLine("rnbqkbnr"),
-                board.showBoard()
+                chessView.showBoard(board)
         );
     }
 
@@ -193,7 +198,7 @@ class BoardTest {
         addPiece(Position.e1, whiteRook);
         addPiece(Position.f1, whiteKing);
 
-        board.print();
+        chessView.showBoard(board);
         assertEquals(20.0, board.calculatePoint(Color.BLACK), 0.1);
         assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.1);
     }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -78,7 +78,6 @@ class BoardTest {
     @Test
     void initialize() {
         board.initialize();
-        assertEquals(32, board.pieceCount());
         String blankRank = appendNewLine("........");
         assertEquals(
                 appendNewLine("RNBQKBNR") +
@@ -153,19 +152,6 @@ class BoardTest {
                 Arguments.of(Position.e6), Arguments.of(Position.f6), Arguments.of(Position.g6),
                 Arguments.of(Position.h6)
         );
-    }
-
-    @DisplayName("임의의 기물을 빈 체스판 위에 추가한다.")
-    @Test
-    void move() {
-        board.initializeEmpty();
-
-        Piece piece = blackRook;
-        Position position = Position.b5;
-        board.move(position, piece);
-
-        assertEquals(piece, board.findPiece(position));
-        System.out.println(board.showBoard());
     }
 
     @DisplayName("체스 프로그램 점수를 계산한다. - whitePawn 같은 열 존재")
@@ -299,5 +285,19 @@ class BoardTest {
         assertEquals(1, board.pieceCount(Type.QUEEN, Color.WHITE));
         assertEquals(1, board.pieceCount(Type.KING, Color.WHITE));
         assertEquals(1, board.pieceCount(Type.ROOK, Color.WHITE));
+    }
+
+    @DisplayName("기물을 현재 위치에서 다른 위치로 이동한다.")
+    @Test
+    void move() {
+        board.initialize();
+
+        Position sourcePosition = Position.b2;
+        Position targetPosition = Position.b3;
+
+        board.move(sourcePosition, targetPosition);
+
+        assertEquals(blankPiece, board.findPiece(sourcePosition));
+        assertEquals(whitePawn, board.findPiece(targetPosition));
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -1,13 +1,18 @@
 package chess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.StringUtils.appendNewLine;
 
 import chess.board.Board;
+import chess.calculator.DefaultPointCalculateStrategy;
+import chess.calculator.PointCalculator;
+import chess.calculator.SameFilePawnPointCalculateStrategy;
 import chess.pieces.Piece;
 import chess.pieces.Piece.Color;
 import chess.pieces.Piece.Type;
+import chess.pieces.PieceFactory;
 import chess.pieces.Position;
 import chess.sorter.Direction;
 import chess.sorter.PointSorter;
@@ -53,25 +58,31 @@ class BoardTest {
 
     private static ChessView chessView;
 
+    private static PointCalculator calculator;
+
     private Board board;
 
 
     @BeforeAll
     static void beforeAll() {
-        whitePawn = Piece.createWhitePawn();
-        blackPawn = Piece.createBlackPawn();
-        whiteRook = Piece.createWhiteRook();
-        blackRook = Piece.createBlackRook();
-        whiteKnight = Piece.createWhiteKnight();
-        blackKnight = Piece.createBlackKnight();
-        whiteBishop = Piece.createWhiteBishop();
-        blackBishop = Piece.createBlackBishop();
-        whiteQueen = Piece.createWhiteQueen();
-        blackQueen = Piece.createBlackQueen();
-        whiteKing = Piece.createWhiteKing();
-        blackKing = Piece.createBlackKing();
-        blankPiece = Piece.createBlank();
+        whitePawn = PieceFactory.createWhitePawn();
+        blackPawn = PieceFactory.createBlackPawn();
+        whiteRook = PieceFactory.createWhiteRook();
+        blackRook = PieceFactory.createBlackRook();
+        whiteKnight = PieceFactory.createWhiteKnight();
+        blackKnight = PieceFactory.createBlackKnight();
+        whiteBishop = PieceFactory.createWhiteBishop();
+        blackBishop = PieceFactory.createBlackBishop();
+        whiteQueen = PieceFactory.createWhiteQueen();
+        blackQueen = PieceFactory.createBlackQueen();
+        whiteKing = PieceFactory.createWhiteKing();
+        blackKing = PieceFactory.createBlackKing();
+        blankPiece = PieceFactory.createBlankPiece();
         chessView = new ChessView();
+        calculator = new PointCalculator(List.of(
+                new DefaultPointCalculateStrategy(),
+                new SameFilePawnPointCalculateStrategy()
+        ));
     }
 
     @BeforeEach
@@ -173,8 +184,8 @@ class BoardTest {
         addPiece(Position.e1, whiteRook);
         addPiece(Position.f1, whiteKing);
 
-        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.1);
-        assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.1);
+        assertEquals(15.0, calculator.calculate(board, Color.BLACK), 0.1);
+        assertEquals(7.0, calculator.calculate(board, Color.WHITE), 0.1);
     }
 
     @DisplayName("체스 프로그램 점수를 계산한다. - 루카스 예시")
@@ -199,8 +210,8 @@ class BoardTest {
         addPiece(Position.f1, whiteKing);
 
         chessView.showBoard(board);
-        assertEquals(20.0, board.calculatePoint(Color.BLACK), 0.1);
-        assertEquals(19.5, board.calculatePoint(Color.WHITE), 0.1);
+        assertEquals(20.0, calculator.calculate(board, Color.BLACK), 0.1);
+        assertEquals(19.5, calculator.calculate(board, Color.WHITE), 0.1);
     }
 
     @DisplayName("체스 프로그램 점수를 계산한다.-모든 기물 세팅")
@@ -208,8 +219,8 @@ class BoardTest {
     void givenAllPieces_calculatePoint() {
         board.initialize();
 
-        assertEquals(38, board.calculatePoint(Color.BLACK), 0.1);
-        assertEquals(38, board.calculatePoint(Color.WHITE), 0.1);
+        assertEquals(38, calculator.calculate(board, Color.BLACK), 0.1);
+        assertEquals(38, calculator.calculate(board, Color.WHITE), 0.1);
     }
 
     @DisplayName("체스 프로그램 점수를 계산한다.- 기물 없음")
@@ -217,8 +228,8 @@ class BoardTest {
     void givenNoPiece_calculatePoint() {
         board.initializeEmpty();
 
-        assertEquals(0.0, board.calculatePoint(Color.BLACK), 0.1);
-        assertEquals(0.0, board.calculatePoint(Color.WHITE), 0.1);
+        assertEquals(0.0, calculator.calculate(board, Color.BLACK), 0.1);
+        assertEquals(0.0, calculator.calculate(board, Color.WHITE), 0.1);
     }
 
 
@@ -304,5 +315,15 @@ class BoardTest {
 
         assertEquals(blankPiece, board.findPiece(sourcePosition));
         assertEquals(whitePawn, board.findPiece(targetPosition));
+    }
+
+    @DisplayName("기물을 현재 위치에서 현재 위치로 이동할 수 없다.")
+    @Test
+    void whenMoveToCurrentPosition_thenFail() {
+        board.initialize();
+
+        Position sourcePosition = Position.b2;
+
+        assertThrows(IllegalArgumentException.class, () -> board.move(sourcePosition, sourcePosition));
     }
 }

--- a/src/test/java/chess/pieces/KingTest.java
+++ b/src/test/java/chess/pieces/KingTest.java
@@ -1,0 +1,62 @@
+package chess.pieces;
+
+import static chess.pieces.PieceTestUtil.assertMove;
+
+import chess.board.Board;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class KingTest {
+    private static Piece whiteKing;
+    private static Piece blackKing;
+    private Board board;
+
+    @BeforeEach
+    void setUp() {
+        board = new Board();
+        board.initializeEmpty();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        whiteKing = PieceFactory.createWhiteKing();
+        blackKing = PieceFactory.createBlackKing();
+
+    }
+
+    @DisplayName("킹의 이동가능한 곳들을 확인한다")
+    @ParameterizedTest
+    @MethodSource
+    void possiblePositionsFromStartPosition(Position src, Position target, Piece king) {
+        board.move(src, king);
+        board.move(src, target);
+        assertMove(board, src, target, king);
+    }
+
+    @MethodSource
+    public static Stream<Arguments> possiblePositionsFromStartPosition() {
+        return Stream.of(
+                Arguments.of(Position.d2, Position.c1, whiteKing),
+                Arguments.of(Position.d2, Position.c2, whiteKing),
+                Arguments.of(Position.d2, Position.c3, whiteKing),
+                Arguments.of(Position.d2, Position.d3, whiteKing),
+                Arguments.of(Position.d2, Position.d1, whiteKing),
+                Arguments.of(Position.d2, Position.e1, whiteKing),
+                Arguments.of(Position.d2, Position.e2, whiteKing),
+                Arguments.of(Position.d2, Position.e3, whiteKing),
+                Arguments.of(Position.d6, Position.c5, blackKing),
+                Arguments.of(Position.d6, Position.c6, blackKing),
+                Arguments.of(Position.d6, Position.c7, blackKing),
+                Arguments.of(Position.d6, Position.d5, blackKing),
+                Arguments.of(Position.d6, Position.d7, blackKing),
+                Arguments.of(Position.d6, Position.e5, blackKing),
+                Arguments.of(Position.d6, Position.e6, blackKing),
+                Arguments.of(Position.d6, Position.e7, blackKing)
+        );
+    }
+}

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -33,19 +33,19 @@ class PieceTest {
 
     private static Stream<Arguments> create_piece() {
         return Stream.of(
-                Arguments.of(Piece.createWhitePawn(), Piece.createBlackPawn(), Type.PAWN),
-                Arguments.of(Piece.createWhiteKnight(), Piece.createBlackKnight(), Type.KNIGHT),
-                Arguments.of(Piece.createWhiteRook(), Piece.createBlackRook(), Type.ROOK),
-                Arguments.of(Piece.createWhiteBishop(), Piece.createBlackBishop(), Type.BISHOP),
-                Arguments.of(Piece.createWhiteQueen(), Piece.createBlackQueen(), Type.QUEEN),
-                Arguments.of(Piece.createWhiteKing(), Piece.createBlackKing(), Type.KING)
+                Arguments.of(PieceFactory.createWhitePawn(), PieceFactory.createBlackPawn(), Type.PAWN),
+                Arguments.of(PieceFactory.createWhiteKnight(), PieceFactory.createBlackKnight(), Type.KNIGHT),
+                Arguments.of(PieceFactory.createWhiteBishop(), PieceFactory.createBlackBishop(), Type.BISHOP),
+                Arguments.of(PieceFactory.createWhiteRook(), PieceFactory.createBlackRook(), Type.ROOK),
+                Arguments.of(PieceFactory.createWhiteQueen(), PieceFactory.createBlackQueen(), Type.QUEEN),
+                Arguments.of(PieceFactory.createWhiteKing(), PieceFactory.createBlackKing(), Type.KING)
         );
     }
 
     @DisplayName("기물이 없는 공간을 나타내는 Blank 피스를 테스트한다.")
     @Test
     void create_blank() {
-        Piece blank = Piece.createBlank();
+        Piece blank = PieceFactory.createBlankPiece();
         assertFalse(blank.isWhite());
         assertFalse(blank.isBlack());
         assertEquals(Type.NO_PIECE, blank.getType());
@@ -55,8 +55,8 @@ class PieceTest {
     @DisplayName("검은색 말과 흰색 말을 구분한다")
     @Test
     void checkColor() {
-        Piece blackPawn = Piece.createBlackPawn();
-        Piece whiteQueen = Piece.createWhiteQueen();
+        Piece blackPawn = PieceFactory.createBlackPawn();
+        Piece whiteQueen = PieceFactory.createWhitePawn();
         assertTrue(blackPawn.isBlack());
         assertFalse(blackPawn.isWhite());
         assertTrue(whiteQueen.isWhite());

--- a/src/test/java/chess/pieces/PieceTestUtil.java
+++ b/src/test/java/chess/pieces/PieceTestUtil.java
@@ -1,0 +1,12 @@
+package chess.pieces;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import chess.board.Board;
+
+public class PieceTestUtil {
+    public static void assertMove(Board board, Position src, Position dest, Piece piece) {
+        assertEquals(PieceFactory.createBlankPiece(), board.findPiece(src));
+        assertEquals(piece, board.findPiece(dest));
+    }
+}


### PR DESCRIPTION
## 구현 내용
### 1. Piece를 상속하는 기물 클래스 생성
+ Piece는 abstract 클래스로 객체 생성 불가능
+ 하위 클래스 생성자 protected로 막고 _PieceFactory_ 클래스에서 기물 생성하도록. 사용하는 쪽에서 구체 클래스에 의존하지 않고 _PieceFactory_ 에서 사용할 수 있도록 해서 DIP원칙(고수준 모듈이 저수준 모듈에 의존하지 않도록) 준수하도록 설계
+ 공통 필드: color, type, directionList(이동 가능한 방향 리스트) 필드.

### 다형성 이용해서 기물별 이동 구현
+  피스가 목적지가 이동 가능한 방향 및 거리인지는 피스에서 테스트,  다른 기물들과의 관계에서 이동가능한지(경로에 같은 팀이 있는지 등)은 보드에서 검사
+ Piece.getPath(): 
  + 현재위치과 목적지 사이의 x, y 차이를 이용해서 해당하는 Direction 찾기
  + 현재 기물이 이동가능한 방향에 해당 Direction 포함되는지 체크
   + Direction을 사용해서 현재위치부터 타겟 위치까지 재귀로 경로 찾기. 
+ _additionalCheck()_: Piece 클래스에 디폴트 메서드로 아무것도 안 하도록 구현해두고 king(), pawn(), blank() 등 추가처리가 필요한 경우 오버라이드해서 사용

### 기물별 테스트 클래스 작성
+ Board에서 현재 위치로 이동/ 같은 편이 있는 위치로 이동 불가 테스트
+ 기물별 테스트 클래스에서 이동 가능한 위치/불가능한 위치테스트
  + 폰은 시작 위치에서만 2칸 이동 가능 테스트도 추가 

## 고민 사항
- piece가 position을 가지도록 하는게 맞나?
- Position enum으로 작성하니  valueOf(int rankNumber, int fileNumber) 에서 rankNumber, fileNumber로 해당하는 Position 객체 찾기 위해서 매번  64개의 Position 순회해야해서 성능 병목될수도 있지 않나?  
   - Find first()시 만족하는 원소 찾으면 순회 멈추는데 실제로 병목이 되나? 
   - 어떻게 개선할 수 있을까?


## 기타
+ 이전 단계에서 진행한 Sorter를 수정. 
  + before: board가 sorter를 필드로 가짐.
  + after: 외부에서 sorter 및 direction를 매개변수로 받음. 외부에서 정렬 로직 결정할 수 있도록 유연성 확보.
